### PR TITLE
Medium: importazione di tutti i post

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,7 +1,7 @@
 <div class="u-nbfc u-flexWrap u-flex u-color-grey-30 u-xs-padding-all-none
   {% if include.flat != true %}u-borderShadow-m u-xs-borderShadow-none u-borderRadius-m{% endif %}
   {{ include.classes | default: 'u-background-white' }} u-sizeFill">
-  {% if include.hasImage != false %}
+  {% if include.hasImage != false and include.image %}
   <div class="u-sizeFull">
     <a class="" {% if include.target == '_blank' %}target="_blank"{% endif %} href="{{ include.link }}">
     <img src="{{ include.image | default: //placehold.it/400x220 }}" class="u-sizeFull" alt="{{ include.alt }}" style="border-bottom: 0.3em solid #06c" />

--- a/_includes/home/block-6.html
+++ b/_includes/home/block-6.html
@@ -29,7 +29,9 @@
     {% assign posts = site.medium_feed | where: "medium_detected_lang", page.lang | sort: "medium_firstpublished_at" | reverse %}
     {% for post in posts limit: 2 %}
       <div class="Grid-cell u-sizeFull u-md-sizeFill u-lg-sizeFill u-margin-r-bottom u-color-white u-flex"
-        style="background-color: {{ post.medium_preview_image_color_avg }}; background-image: url({{ post.medium_preview_image_url }});
+        style="
+          {% if post.medium_preview_image_color_avg %}background-color: {{ post.medium_preview_image_color_avg }}; {% endif %}
+          {% if post.medium_preview_image_url %}background-image: url({{ post.medium_preview_image_url }}); {% endif %}
           background-blend-mode: multiply; background-size: cover; min-height: 300px">
         <div class="u-padding-r-all u-text-r-xl u-flex u-flexWrap u-flexAlignSelfStretch">
           <div class="u-flexAlignSelfEnd">


### PR DESCRIPTION
L'utilizzo di `latest` permette di usare il parametro `count` per ottenere più di 7 post.

Alcune modifiche necessarie:
- rimossa versione inglese (post già presenti nella chiamata al nuovo feed)
- i post sono in un oggetto diverso all'interno del JSON
- controllo post senza `previewImage` (al momento solo uno)