### PR TITLE
Inserito riferimento ai kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 Questo repository contiene il codice sorgente di [designers.italia.it](https://designers.italia.it), ***la comunità dei designer dei servizi pubblici digitali in Italia***.
 
+Il repository contiene anche alcuni asset (es. file sketch) o i riferimenti agli asset (es. link a un documento docs italia, oppure a un altro repo specifico) dei kit per il design della Pubblica Amministrazione italiana. Ogni commento o proposta relativa all'evoluzione dei kit può essere fatta utilizzando le issues di GitHub
+
 Il sito è sviluppato con Jekyll. Per configurare un ambiente di sviluppo è sufficiente eseguire i seguenti comandi:
 
     $ bundle install


### PR DESCRIPTION
I kit sono ospitati o lincati  nel repo e esiste la possibilità di creare issue relative ai kit

NOTA
in tutte le pagine di presentazione dei kit sarebbe opportuno inserire creare un paragrafo (diciamo sotto alle linee guida) in cui inserire il link al repo specifico - se presente e in altrenativa appunto il link alle issues
@francescozaia 
Qui l'esempio in cui il kit (ad esempio lo user journey) non abbia un repo github specifico
Come partecipare
Grazie a dei repository pubblici, è sufficiente avere un account su GitHub per proporre modifiche o aggiungere nuovi elementi ai kit, attraverso delle pull request o delle issue.
https://github.com/italia/designers.italia.it/issues