### PR TITLE
Guida al linguaggio

### DIFF
--- a/_pages/it/come-partecipo.md
+++ b/_pages/it/come-partecipo.md
@@ -25,6 +25,8 @@ blocks:
       url: 'https://github.com/italia/design-icon-kit'
     - label: Partecipa allo UI Kit
       url: 'https://github.com/italia/design-ui-kit'
+    - label: Partecipa alla Guida al linguaggio
+      url: 'https://github.com/italia/writing-toolkit'
     - label: Partecipa al Web Toolkit
       url: 'https://github.com/italia/design-web-toolkit'
     - label: Partecipa a Bootstrap Italia


### PR DESCRIPTION
Ciao, ho inserito tra i riferimenti diretti al repo anche quello al repo della Guida al linguaggio

- label: Partecipa alla Guida al linguaggio
      url: 'https://github.com/italia/writing-toolkit'