### PR TITLE
Fix #141. Add versioning to enable cache invalidation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # prepare a couple reusable parameters
-var_1: &cache_key dependencies-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+var_1: &cache_key v0-dependencies-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
 anchor_1: &job_defaults
   working_directory: /tmp/designers.italia.it
   docker:


### PR DESCRIPTION
## This PR 

Adds Cache invalidation, which is useful to fix build issues
 when circleci cache corrupts.

## It's done

Prefixing the cache with a `v0` like we have in other repos.