### PR TITLE
Fix/minor css adjust

### DIFF
--- a/_includes/home/block-04-notizie.html
+++ b/_includes/home/block-04-notizie.html
@@ -1,11 +1,11 @@
 <section class="HomeBlk2 u-posRelative">
 
   <img alt="" class="u-hidden u-md-inline u-lg-inline" role="presentation"
-       src="{{ '/assets/images/blk2/balloons.svg' | relative_url }}" style="position: absolute; top: 20%; left: 15%">
+       src="{{ '/assets/images/blk2/balloons.svg' | relative_url }}" style="position: absolute; top: 10%; left: 15%">
   <img alt="" class="u-hidden u-md-inline u-lg-inline" role="presentation"
-       src="{{ '/assets/images/blk2/kite.svg' | relative_url }}" style="position: absolute; top: 20%; right: 10%">
+       src="{{ '/assets/images/blk2/kite.svg' | relative_url }}" style="position: absolute; top: 10%; right: 10%">
   <img alt="" class="u-hidden u-md-inline u-lg-inline" role="presentation"
-       src="{{ '/assets/images/blk2/plane.svg' | relative_url }}" style="position: absolute; top: 45%; left: 20%">
+       src="{{ '/assets/images/blk2/plane.svg' | relative_url }}" style="position: absolute; bottom: 15%; left: 30%">
   <img alt="" class="u-hidden u-md-inline u-lg-inline" role="presentation"
        src="{{ '/assets/images/blk2/robot-flying.svg' | relative_url }}" style="position: absolute; bottom: 20%; left: 10%">
   <img alt="" class="u-hidden u-md-inline u-lg-inline" role="presentation"
@@ -19,7 +19,7 @@
         <h2 class="u-text-r-xxl u-textWeight-700 u-padding-r-top">Le notizie</h2>
       </div>
 
-      <div class="Grid Grid--withGutter u-padding-all-l guides-grid u-posRelative">
+      <div class="Grid Grid--withGutter Grid--equalHeight u-padding-all-l guides-grid u-posRelative">
         {%- if site.medium_feed -%}
         {%- assign posts = site.medium_feed | where: "medium_detected_lang", page.lang | sort: "medium_firstpublished_at"
         | reverse -%}
@@ -38,21 +38,21 @@
         {% assign mediumSubtitle = mediumPost.medium_subtitle | strip_html | truncatewords: 13 %}
 
         {% assign _url = mediumPost.medium_url %}
-        <div class="notizie-inline Grid-cell u-lg-size2of4 u-margin-top-s {% if showThisMediumPost != nil %} u-posRelative{% endif %}">
+        <div class="notizie-inline Grid-cell u-md-size2of4 u-lg-size2of4 u-margin-top-s {% if showThisMediumPost != nil %} u-posRelative{% endif %}">
           {% include card.html
             date_prepend = "Storia "
             date = _date
             title = mediumPost.medium_title
             alt = mediumPost.medium_title
             link = _url
-            text = mediumSubtitle
+            subtitle = mediumSubtitle
             link_text = "Continua su Medium"
             hasImage = true
             hasSocial = false
             rowImage = true
             image = mediumPost.medium_preview_image_url
             target = "_blank"
-            classes = "u-background-grey-15"
+            classes = "u-background-white"
             flatTitle = true
           %}
         </div>
@@ -63,7 +63,7 @@
         {% assign pinnedPostsCount = pinnedPostsCount | plus: 1 %}
         {%- assign _excerpt = post.excerpt | markdownify | remove: '<p>' | remove: '</p>' -%}
         {%- assign showCategories = post.categories | where: post.homeHideCategories, false -%}
-        <div class="notizie-post Grid-cell u-sm-size1of2 u-md-size1of2 u-lg-size1of4 u-margin-top-s u-posRelative">
+        <div class="notizie-post Grid-cell u-sm-size1of2 u-md-size1of4 u-lg-size1of4 u-margin-top-s u-posRelative">
           {% include card.html
             date_prepend = post.date_prepend
             date = post.date
@@ -72,7 +72,7 @@
             alt = post.title
             link = post.url
             homeBottomLink = post.homeBottomLink
-            classes = 'u-background-grey-15'
+            classes = 'u-background-white'
             categories = showCategories
           %}
         </div>
@@ -81,7 +81,7 @@
         {% assign normalPostsToShow =  2 | minus: pinnedPostsCount %}
         {%- if normalPostsToShow > 0 -%}
         {% for post in normalPosts limit: normalPostsToShow %}
-        <div class="notizie-post Grid-cell u-sm-size1of2 u-md-size1of2 u-lg-size1of4 u-margin-top-s">
+        <div class="notizie-post Grid-cell u-sm-size1of2 u-md-size1of4 u-lg-size1of4 u-margin-top-s">
           {% include card.html
             date_prepend = post.date_prepend
             date = post.date
@@ -90,7 +90,7 @@
             alt = post.title
             link = post.url
             homeBottomLink = post.homeBottomLink
-            classes = 'u-background-grey-15'
+            classes = 'u-background-white'
             categories = showCategories
           %}
         </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -34,7 +34,7 @@ lang: it
 </div>
 
 <div class="u-background-grey-15 u-layout-r-withGutter u-padding-top-xl u-padding-bottom-xxl u-posRelative u-zindex-30">
-  <div class="Grid">
+  <div class="Grid u-layout-wide u-layoutCenter">
     <div class="Grid-cell u-sizeFull u-md-size7of12 u-lg-size7of12">
       <div class="u-margin-r-top u-margin-r-bottom">
         <h2 class="u-color-grey-ui-kit u-text-r-m u-textWeight-400 u-margin-r-bottom">{{ t.news_main_title }}</h2>
@@ -45,7 +45,7 @@ lang: it
       {% for post in posts %}
       {%- if post.medium_post_id == mediumPostidForHome -%}
       {% assign _url = post.medium_url %}
-      <div class="u-margin-bottom-xxl u-border-bottom-xxs u-padding-bottom-xl u-color-grey-30 u-posRelative">
+      <div class="u-margin-bottom-xxl u-border-bottom-xxs u-padding-bottom-xl u-color-grey-30 u-posRelative u-background-white u-padding-r-all">
         <img class="pinnedBookmark" role="presentation" src="{{ '/assets/images/pinned_bookmark-new.svg' | relative_url }}">
         {% include card.html
         date = _date

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -58,7 +58,7 @@ lang: it
         image = post.medium_preview_image_url
         categories = post.medium_tagsarray
         flat = true
-        classes = 'u-background-grey-15'
+        classes = 'u-background-white'
         target = '_blank'
         %}
       </div>
@@ -82,7 +82,7 @@ lang: it
         image = post.medium_preview_image_url
         categories = post.medium_tagsarray
         flat = true
-        classes = 'u-background-grey-15'
+        classes = 'u-background-white'
         target = '_blank'
         %}
       </div>
@@ -128,7 +128,7 @@ lang: it
               text = _excerpt
               link = post.url
               homeBottomLink = post.homeBottomLink
-              classes = 'u-background-grey-15'
+              classes = 'u-background-white'
               categories = showCategories
             %}
           </div>
@@ -150,7 +150,7 @@ lang: it
               text = _excerpt
               link = post.url
               homeBottomLink = post.homeBottomLink
-              classes = 'u-background-grey-15'
+              classes = 'u-background-white'
               categories = showCategories
             %}
           </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -70,7 +70,7 @@ lang: it
       {% assign _url = post.medium_url %}
       {% assign _date = post.medium_firstpublished_at | divided_by: 1000 | date: t.formatDate %}
       {%- if post.medium_post_id != mediumPostidForHome -%}
-      <div class="u-margin-bottom-xxl u-border-bottom-xxs u-padding-bottom-xl u-color-grey-30">
+      <div class="u-margin-bottom-xxl u-border-bottom-xxs u-padding-bottom-xl u-color-grey-30 u-background-white u-padding-r-all">
         {% include card.html
         date = _date
         author = post.medium_author


### PR DESCRIPTION
Ho fatto qualche aggiustamento visivo (minor classi css) per: 
- il blocco notizie in home page
  - ora a 4 colonne anche su schermi da 1280px
  - sprite visibili non più nascosti dalle card
  - dimensioni testi coerenti tra le tre card
- la pagina notizie
  - larghezza layout
  - fondi bianchi sulle card
  - alcuni padding

Vedi anteprima vercel. @westcoast dai un'occhiata quando hai tempo (no pressure!) ma mi pare sia tutto apposto. 