### PR TITLE
feat/Enabled outbout links on resources

### DIFF
--- a/_kits/it/analisi-contesto.md
+++ b/_kits/it/analisi-contesto.md
@@ -45,6 +45,9 @@ superAccordion:
         - title: Mappa degli attori
           icon: "/assets/icons/pencil.svg"
           description: Uno schema che rappresenta la rete di relazioni tra l’utente e gli altri attori del contesto
+          url: 'https://docs.google.com/presentation/d/1kxsFXSesX2kCOR1L3SbPfYqFInFhf_A7RW3_2xZ943o/edit?usp=sharing'
+          urlText: 'Vai alla risorsa'
+          urlArialabel: 'Vai alla risorsa (link esterno)'
           link: <a href='https://docs.google.com/presentation/d/1kxsFXSesX2kCOR1L3SbPfYqFInFhf_A7RW3_2xZ943o/edit?usp=sharing' aria-label="Vai alla risorsa (link esterno)" target="_blank">Vai alla risorsa</a>
         - title: Mappa dell'ecosistema
           icon: "/assets/icons/pencil.svg"

--- a/_kits/it/analisi-contesto.md
+++ b/_kits/it/analisi-contesto.md
@@ -48,7 +48,6 @@ superAccordion:
           url: 'https://docs.google.com/presentation/d/1kxsFXSesX2kCOR1L3SbPfYqFInFhf_A7RW3_2xZ943o/edit?usp=sharing'
           urlText: 'Vai alla risorsa'
           urlArialabel: 'Vai alla risorsa (link esterno)'
-          link: <a href='https://docs.google.com/presentation/d/1kxsFXSesX2kCOR1L3SbPfYqFInFhf_A7RW3_2xZ943o/edit?usp=sharing' aria-label="Vai alla risorsa (link esterno)" target="_blank">Vai alla risorsa</a>
         - title: Mappa dell'ecosistema
           icon: "/assets/icons/pencil.svg"
           description: Un diagramma che schematizza le relazioni e transazioni tra gli elementi coinvolti nel servizio pubblico

--- a/_layouts/kit.html
+++ b/_layouts/kit.html
@@ -148,11 +148,7 @@ layout: default
                          In lavorazione
                       {% else %}
                           {% if resource.url %}
-                            <a href="{{resource.url}}"
-                            aria-label="{{resource.urlArialabel}}" rel="noopener"
-                            target="_blank"
-                            onclick="captureOutboundLink('{{resource.url}}');
-                            return false;" >{{resource.urlText}}</a>
+                            <a href="{{resource.url}}" aria-label="{{resource.urlArialabel}}" target="_blank" rel="noopener" onclick="captureOutboundLink('{{resource.url}}');return false;">{{resource.urlText}}</a>
                           {% else if resource.link %}
                             <!-- old tag without outbound link -->
                             {{resource.link}}

--- a/_layouts/kit.html
+++ b/_layouts/kit.html
@@ -147,7 +147,16 @@ layout: default
                       {% if resource.disabled == true %}
                          In lavorazione
                       {% else %}
-                        {{resource.link}}
+                          {% if resource.url %}
+                            <a href="{{resource.url}}"
+                            aria-label="{{resource.urlArialabel}}" rel="noopener"
+                            target="_blank"
+                            onclick="captureOutboundLink('{{resource.url}}');
+                            return false;" >{{resource.urlText}}</a>
+                          {% else if resource.link %}
+                            <!-- old tag without outbound link -->
+                            {{resource.link}}
+                          {% endif %}
                         {% if resource.icon %}
                           <img alt="" class="u-margin-left-xs" src="{{resource.icon}}" />
                         {% endif %}


### PR DESCRIPTION
Added 
- outbound links tag code for single resources
- generalization on how to document each resource link: was just `link` > now `url`, `urlArialabel` and `urlText`

The code checks if the kit page has the new resource link fields above (url, urlArialabel, urlText) and, if so, it will use them to build the correct `<a` tag with the outbound link and the `rel="noopener"`. If not, it will continue to use the old habits ;-) and the old `<a` tag to don't break anything in the meantime... 

@danielaiozzo let's review this together in a couple of days
