### PR TITLE
chore: remove mobilizon link in news

### DIFF
--- a/_posts/2022-03-25-Community_call_design_sinergia_universita_PA.md
+++ b/_posts/2022-03-25-Community_call_design_sinergia_universita_PA.md
@@ -25,4 +25,4 @@ Consapevole del valore generato sia per le amministrazioni pubbliche sia per gli
 
 Appuntamento dunque alla **community call di mercoledì 6 aprile**, dove torneremo tra i banchi per parlare dell’Atlante della trasformazione digitale della PA e dare visibilità ad altri **esempi virtuosi di collaborazione tra Università ed enti pubblici** nell’ambito della progettazione per la Pubblica Amministrazione, con l’obiettivo di raccontare le iniziative intraprese, ispirare interlocutori e, secondo una logica aperta, ampliare la conoscenza e le risorse sul tema.
 
-[Registrati all’evento per partecipare](https://mobilizon.it/events/a6349415-b43f-4b63-8c92-c06a647a1cc0){:target="_blank" rel="noopener noreferrer"}. **Ti aspettiamo il 6 aprile alle 15.30 [a questo indirizzo](https://blue.meet.garr.it/b/ric-h2n-rc5-lkj)**!
+**Ti aspettiamo il 6 aprile alle 15.30 [a questo indirizzo](https://blue.meet.garr.it/b/ric-h2n-rc5-lkj){:target="_blank" rel="noopener noreferrer"}**!


### PR DESCRIPTION
mobilizon.it is down, let's remove the link from the news