### PR TITLE
TEST/container-xxl

### DIFF
--- a/src/components/header-center/header-center.js
+++ b/src/components/header-center/header-center.js
@@ -43,7 +43,7 @@ const HeaderCenter = ({data}) => {
 	
 	return (
 		<div className="it-header-center-wrapper">
-			<div className="container">
+			<div className="container-xxl">
 				<div className="row">
 					<div className="col-12">
 						<div className="it-header-center-content-wrapper">

--- a/src/components/header-nav/header-nav.js
+++ b/src/components/header-nav/header-nav.js
@@ -9,7 +9,7 @@ import DropdownMenu from "../dropdown-menu/dropdown-menu"
 const HeaderNav = ({data}) => {
 	return(
 	<div className={"it-header-navbar-wrapper" + ' '+data.theme} id={data.id}>
-		<div className="container">
+		<div className="container-xxl">
 			<div className="row">
 				<div className="col-12">
 					<nav className="navbar navbar-expand-lg has-megamenu" aria-label={data.ariaLabel}>

--- a/src/components/header-slim/header-slim.js
+++ b/src/components/header-slim/header-slim.js
@@ -6,7 +6,7 @@ import ListItem from "../list-item/list-item"
 const HeaderSlim = ({data}) => {
 	return (
 		<div className="it-header-slim-wrapper">
-			<div className="container">
+			<div className="container-xxl">
 				<div className="row">
 					<div className="col-12">
 						<div className="it-header-slim-wrapper-content">

--- a/src/components/highlight/highlight.js
+++ b/src/components/highlight/highlight.js
@@ -48,7 +48,7 @@ const Highlight = (
 
 	return (
 		<section className={styles} aria-labelled-by={id}>
-			<div className="container">
+			<div className="container-xxl">
 				<div className="row">
 					<div className="col-12">
 						<div className={classes}>


### PR DESCRIPTION
I am testing, on 

- highlight
- header

components, the use of class `container-xxl` ([reference](https://getbootstrap.com/docs/5.0/layout/containers/) on B5 website), and not just the simple `container`, to obtain a better use of right and left spaces and dimensions on some middle-size devices (eg. Ipad Pro 11' landscape mode).