### PR TITLE
chore(build): fix the build when using bundler > 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,12 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.20.1)
@@ -110,7 +116,10 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  arm64-darwin
   ruby
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   html-proofer (~> 3.19.1)
@@ -129,4 +138,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   2.3.24


### PR DESCRIPTION
bundler > 2.1 needs to be instructed on what architectures to use when fetching the binary packages, otherwise it'll always try to compile the gem.

The Vercel preview uses bundler 2.3, so let's bump the version.