### PR TITLE
Fix/a11y wrap checkbox

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 const Checkbox = ({
     chkId,
     label,
+    labelId,
     checked,
     customStyle,
     handleChange,
@@ -22,7 +23,7 @@ const Checkbox = ({
     return (
         <div className={"form-check " + customStyle} onClick={() => onClickEvent()}>
             <input id={chkId} type="checkbox" checked={isChecked} {...props}/>
-            <label htmlFor={chkId}>{label}</label>
+            <label htmlFor={labelId}>{label}</label>
         </div>
     );
 };

--- a/src/components/component-view/component-view.js
+++ b/src/components/component-view/component-view.js
@@ -110,7 +110,7 @@ const ComponentView = ({
             </h2>
             <div className="d-flex justify-content-between align-items-center">
               {content &&
-                <Checkbox id="wrap" label="Wrap" customStyle={'me-3'} checked={wrappedCode} handleChange={(val) => setWrappedCode(val)} />
+                <Checkbox id={idPrefix + '-' + 'wrap'} label='Wrap' labelId={idPrefix + '-' + 'wrap'} customStyle={'me-3'} checked={wrappedCode} handleChange={(val) => setWrappedCode(val)} />
               }
               {content &&
                 <a href="" onClick={(e) => copyToClipboard(e, content)} aria-label={accordionSrCopyLabel}>


### PR DESCRIPTION
@astagi This PR is to fix the two a11y issues we have on the latest added wrap checkbox (component viewer): 
- we need unique ids for each component viewer checkbox
- the label "for" (htmlFor) prop is empty 🧐, I don't understand why

This branch contains a solution that seems ok for a11y and markup code but, it currently breaks the wrap function, can you check it? 