### PR TITLE
fix: workaround for textarea labels overlapping the content

### DIFF
--- a/src/components/feedback/components/form-no/FormNo.js
+++ b/src/components/feedback/components/form-no/FormNo.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useRef } from "react"
 import ImageResponsive from "../../../image-responsive/image-responsive"
+import LabelTextArea from "../../../label-textarea/label-text-area"
 import Link from "../../../link/link"
 import Icon from "../../../icon/icon"
 
@@ -154,8 +155,7 @@ const FormNo = ({ onResult, state }) => {
         </legend>
         <div className="px-3 px-lg-5 pt-5 pb-1 rounded shadow-lg">
           <div className="form-group">
-            <label htmlFor="feedbackText" className="custom-label">Risposta</label>
-            <textarea className="form-control" rows="3" maxLength="200" id="feedbackText" name="feedbackText" />
+            <LabelTextArea id="feedbackText" label="Risposta" rows="3" maxLength="200" />
             <small className="form-control form-text">Hai a disposizione 200 caratteri</small>
           </div>
         </div>

--- a/src/components/feedback/feedback.scss
+++ b/src/components/feedback/feedback.scss
@@ -16,11 +16,6 @@
     line-height: 1.2;
   }
 
-  label {
-    font-weight: 400;
-    color: var(--bs-body-color);
-  }
-
   .custom-label {
     text-transform: uppercase;
     font-size: 0.7777777777777778rem;

--- a/src/components/label-textarea/label-text-area.js
+++ b/src/components/label-textarea/label-text-area.js
@@ -1,0 +1,40 @@
+import React from "react"
+import { useEffect, useState } from "react";
+import { Input } from "bootstrap-italia"
+
+const LabelTextArea = (props) => {
+    const {
+        id,
+        value,
+        onChange,
+        label = "",
+        ...opts
+    } = props;
+    const [message, setMessage] = useState(value);
+    const handleChange = event => {
+        setMessage(event.target.value);
+        if (typeof onChange === "function") {
+            onChange({
+                value: event.target.value
+            });
+        }
+    };
+    useEffect(() => {
+        new Input(document.getElementById(id))
+    });
+    return (
+        <>
+            <label htmlFor={id}>{label}</label>
+            <textarea
+                id={id}
+                className="form-control"
+                onChange={handleChange}
+                {...opts}
+            >
+              {message}
+            </textarea>
+        </>
+    )
+}
+
+export default LabelTextArea


### PR DESCRIPTION
Copy the TextInput component to workaround and use it for the feedback UI textarea to workaround the overlapping label.

Fix #528.