### PR TITLE
feat: implement client side redirects

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -86,30 +86,8 @@ module.exports = {
         enableJSErrorTracking: true,
       },
     },
-    /*{
-      resolve: 'gatsby-plugin-htaccess',
-      // docs here: https://www.npmjs.com/package/gatsby-plugin-htaccess
-      options: {
-        RewriteBase: true,
-        https: true,
-        www: true,
-        SymLinksIfOwnerMatch: true,
-        host: 'designers.italia.it', // if 'www' is set to 'false', be sure to also remove it here!
-        ErrorDocument: `
-          ErrorDocument 401 /error_pages/401.html
-          ErrorDocument 404 /error_pages/404.html
-          ErrorDocument 500 /error_pages/500.html
-        `,
-        redirect: [
-          // redirects go here
-          'RewriteRule ^not-existing-url/?$ /existing-url [R=301,L,NE]',
-        ],
-        custom: `
-            # This is a custom rule!
-            # This is a another custom rule!
-        `,
-      },
-    },*/
+    // This must be the last plugin in the array
+    `gatsby-plugin-meta-redirect`,
   ],
   pathPrefix: '/',
   flags: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -107,3 +107,36 @@ exports.onCreateNode = async ({
     createParentChildLink({ parent: node, child: contentNode })
   }
 }
+
+exports.createPages = async ({ graphql, actions }) => {
+  const { createRedirect } = actions
+
+  const redirs = await graphql(`
+    {
+      allContent (filter: { metadata: { redirect_from: { ne: null } } }) {
+        edges {
+          node {
+            seo {
+              pathname
+            }
+            metadata {
+              redirect_from
+            }
+          }
+        }
+      }
+    }
+  `
+  )
+
+  redirs.data.allContent.edges.forEach((edge) => {
+    const node = edge.node
+
+    node.metadata.redirect_from.forEach((fromPath) => {
+      const toPath = edge.node.seo.pathname
+      console.log(`Creating redirect: ${fromPath} -> ${toPath}...`)
+
+      createRedirect({ fromPath, toPath, })
+    })
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "gatsby-plugin-htaccess": "^1.4.0",
         "gatsby-plugin-image": "^2.24.0",
         "gatsby-plugin-matomo": "^0.14.0",
+        "gatsby-plugin-meta-redirect": "^1.1.1",
         "gatsby-plugin-sass": "^5.23.0",
         "gatsby-plugin-sharp": "^4.24.0",
         "gatsby-source-filesystem": "^4.24.0",
@@ -11120,6 +11121,38 @@
         "gatsby": "^4.0.0 || ^5.0.0",
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-meta-redirect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-meta-redirect/-/gatsby-plugin-meta-redirect-1.1.1.tgz",
+      "integrity": "sha512-Oc4qgU3SlDUM9qoxIMKO+re2bdMs3/a2KXrfL65gb8XMLsHylBbveWtXZRhgjd2QDL/49RX4S9SEykuadRju2w==",
+      "dependencies": {
+        "fs-extra": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gatsby-plugin-meta-redirect/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/gatsby-plugin-meta-redirect/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/gatsby-plugin-page-creator": {
@@ -26176,7 +26209,7 @@
         "@parcel/fs": "2.6.2",
         "@parcel/logger": "2.6.2",
         "@parcel/utils": "2.6.2",
-        "lmdb": "2.6.0"
+        "lmdb": "2.5.2"
       }
     },
     "@parcel/codeframe": {
@@ -32859,6 +32892,34 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.14.0.tgz",
       "integrity": "sha512-zRC+hfqYv5DUXsAnfuEV3x2SkyP/ou/jy9TDxRA3NnxarpBpM+i3h6Rcc4nMmsPq+lEJiQqhBSapw4MTjwqS2A==",
       "requires": {}
+    },
+    "gatsby-plugin-meta-redirect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-meta-redirect/-/gatsby-plugin-meta-redirect-1.1.1.tgz",
+      "integrity": "sha512-Oc4qgU3SlDUM9qoxIMKO+re2bdMs3/a2KXrfL65gb8XMLsHylBbveWtXZRhgjd2QDL/49RX4S9SEykuadRju2w==",
+      "requires": {
+        "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
     },
     "gatsby-plugin-page-creator": {
       "version": "4.24.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gatsby-plugin-htaccess": "^1.4.0",
     "gatsby-plugin-image": "^2.24.0",
     "gatsby-plugin-matomo": "^0.14.0",
+    "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-sass": "^5.23.0",
     "gatsby-plugin-sharp": "^4.24.0",
     "gatsby-source-filesystem": "^4.24.0",

--- a/src/data/content/community/piano-attivita.yaml
+++ b/src/data/content/community/piano-attivita.yaml
@@ -17,9 +17,11 @@
 # ————————————————————————————————————————————
 # CREATEPAGE GATSBY
 # ————————————————————————————————————————————
-metadata: 
+metadata:
   template:
     name: level2
+  redirect_from:
+    - /it/piano-attivita
 
 # ————————————————————————————————————————————
 # SEO, OPENGRAPH
@@ -194,7 +196,7 @@ components:
       centered: true
       text: | #C
         Le attività più importanti, gli obiettivi e i traguardi realizzati
-      
+
       components:
 
        # TXT + IMG + CTA BLOCK
@@ -223,7 +225,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
- 
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -233,7 +235,7 @@ components:
           title: "Rilascio del quadro sinottico servizi al cittadino" #C
           text: | #C
             Pubblicazione su Medium di articoli di descrizione e approfondimento del quadro sinottico.
-   
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -255,7 +257,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-        
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -265,7 +267,7 @@ components:
           title: "Design system: definizione supporto evolutivo Design React Kit" #C
           text: | #C
             Definizione supporto all'evoluzione della libreria community-driven che implementa il design system in React.
-          ctas: 
+          ctas:
           - label: Segui le lavorazioni nella PR dedicata
             url: https://github.com/italia/design-react-kit/pull/885
             screenReaderText: " (si apre in una nuova finestra)" #C
@@ -298,7 +300,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-              
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -307,10 +309,10 @@ components:
           specular: false
           title: "Modelli: rilascio App di valutazione" #C
           text: | #C
-            Pubblicazione su GitHub di nuovi strumenti a supporto della corretta adesione ai modelli per i siti istituzionali dei Comuni e delle scuole.  
-            
-            Applicativi desktop che aiutano a valutare la qualità, le caratteristiche e la corrispondenza ad alcuni dei criteri di conformità della misura 1.4.1 Esperienza del cittadino nei servizi pubblici digitali. 
-            
+            Pubblicazione su GitHub di nuovi strumenti a supporto della corretta adesione ai modelli per i siti istituzionali dei Comuni e delle scuole.
+
+            Applicativi desktop che aiutano a valutare la qualità, le caratteristiche e la corrispondenza ad alcuni dei criteri di conformità della misura 1.4.1 Esperienza del cittadino nei servizi pubblici digitali.
+
             Sono di supporto agli sviluppatori dei siti istituzionali per verificare la corretta implementazione del modello Comuni e del modello Scuole, sia durante che dopo lo sviluppo, e così informare eventuali modifiche o piani di miglioramento.
           ctas:
           - label: Vai alla App di valutazione modelli #C
@@ -323,8 +325,8 @@ components:
               align: middle
               hidden: true
               size: sm
-              addonClasses: ms-2 
-         
+              addonClasses: ms-2
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           title: 2022 — Q3 #C
@@ -339,8 +341,8 @@ components:
           specular: false
           title: "Avvio riprogettazione sito designers.italia.it" #C
           text: | #C
-            Avvio attività per una nuova versione che tenga conto dei suggerimenti della community, degli aggiornamenti al design system e del tema accessibilità. Le fasi di progettazione e realizzazione saranno incorso fino a tutto Q4. 
-          ctas: 
+            Avvio attività per una nuova versione che tenga conto dei suggerimenti della community, degli aggiornamenti al design system e del tema accessibilità. Le fasi di progettazione e realizzazione saranno incorso fino a tutto Q4.
+          ctas:
           - label: Segui i lavori sul ramo next della repository GitHub
             url: https://github.com/italia/designers.italia.it/tree/next
             screenReaderText: " (si apre in una nuova finestra)" #C
@@ -351,7 +353,7 @@ components:
               align: middle
               hidden: true
               size: sm
-              addonClasses: ms-2 
+              addonClasses: ms-2
           - label: Visita la board con le attività in corso
             url: https://github.com/orgs/italia/projects/15
             screenReaderText: " (si apre in una nuova finestra)" #C
@@ -362,8 +364,8 @@ components:
               align: middle
               hidden: true
               size: sm
-              addonClasses: ms-2 
- 
+              addonClasses: ms-2
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -372,7 +374,7 @@ components:
           specular: false
           title: "Progettazione quadro sinottico servizi al cittadino" #C
           text: | #C
-            Progettazione di un quadro sinottico che crei un linguaggio comune tra chi progetta, chi sviluppa soluzioni di servizi digitali al cittadino e le amministrazioni che le devono gestire. Definizione dei diversi ambiti in cui viene usata la parola servizio. Definizione dei diversi livelli di granularità di un servizio e come vengono chiamati dal cittadino, dalla Pubblica Amministrazione e dagli ambienti tecnici. 
+            Progettazione di un quadro sinottico che crei un linguaggio comune tra chi progetta, chi sviluppa soluzioni di servizi digitali al cittadino e le amministrazioni che le devono gestire. Definizione dei diversi ambiti in cui viene usata la parola servizio. Definizione dei diversi livelli di granularità di un servizio e come vengono chiamati dal cittadino, dalla Pubblica Amministrazione e dagli ambienti tecnici.
 
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
@@ -401,7 +403,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-        
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -422,7 +424,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-                
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -444,7 +446,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-              
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -464,8 +466,8 @@ components:
               align: middle
               hidden: true
               size: sm
-              addonClasses: ms-2      
-        
+              addonClasses: ms-2
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -487,7 +489,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-        
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -507,8 +509,8 @@ components:
               align: middle
               hidden: true
               size: sm
-              addonClasses: ms-2      
-              
+              addonClasses: ms-2
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           title: 2022 — Q1 #C
@@ -536,7 +538,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-        
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -546,7 +548,7 @@ components:
           title: "Modello scuole e modello Comuni" #C
           text: | #C
             Avvio delle attività di individuazione e modellizzazione dei principali flussi di servizi digitali al cittadino.
-                
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -556,10 +558,10 @@ components:
           title: "Design system" #C
           text: | #C
             Avvio delle attività operative di aggiornamento: assessment di accessibilità e coerenza delle librerie, e stesura piano di ricerca.
-            Analisi e pianificazione delle evolutive delle librerie tecnologiche (Bootstrap Italia, Design React Kit) e visuali (UI kit e Wireframe Kit) in parallelo. 
-            
+            Analisi e pianificazione delle evolutive delle librerie tecnologiche (Bootstrap Italia, Design React Kit) e visuali (UI kit e Wireframe Kit) in parallelo.
+
             Predisposizione piano di ricerca per comprendere bisogni degli stakeholder del design system del Paese e coinvolgerli in un processo di validazione continua delle lavorazioni in corso.
-              
+
         # TXT + IMG + CTA BLOCK
         - name: TextImageCta
           headingLevel: 4
@@ -581,7 +583,7 @@ components:
               hidden: true
               size: sm
               addonClasses: ms-2
-  
+
     # —
     # EDITORIAL #C #I
     # —
@@ -606,7 +608,7 @@ components:
             url: https://designers.italia.it/piano-attivita #M
             screenReaderText: " (si apre in una nuova finestra)" #C
             blank: true #M #C true if new tab for external links
-            icon: 
+            icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
               align: middle


### PR DESCRIPTION
Implement client side redirects from YAML content in src/data/content
by using the metadata.redirect_from key.

Small gotcha: redirects don't get created locally in development
mode, but they do only in production (and preview), because
gatsby-plugin-meta-redirect uses `onPostBuild()` which is invoked only
after `npm run build`.

Fix #420.
