### PR TITLE
fix: add fallback for the git last modified time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26249,7 +26249,7 @@
         "@parcel/fs": "2.6.2",
         "@parcel/logger": "2.6.2",
         "@parcel/utils": "2.6.2",
-        "lmdb": "2.5.2"
+        "lmdb": "2.6.0"
       }
     },
     "@parcel/codeframe": {

--- a/src/pages/{content.relativePath}.js
+++ b/src/pages/{content.relativePath}.js
@@ -26,7 +26,7 @@ const TEMPLATES = {
 
 const Page = ({ pageContext, location, data: { content } }) => {
   const Template = content.metadata.template ? TEMPLATES[content.metadata.template.name] : TemplateBase
-  const lastModified = content.parent.fields.gitLogLatestDate
+  const lastModified = content?.parent?.fields?.gitLogLatestDate || new Date(0).toISOString()
 
   return(
     <Template Pagedata={content} pageContext={pageContext} location={location} lastModified={lastModified}>
@@ -810,7 +810,7 @@ export const query = graphql`
             # images {
             #  img
             #  alt
-            # }          
+            # }
           }
           background
           title


### PR DESCRIPTION
Don't fail getting the last modified time when a new page is created locally and has not been yet commited to the repo.

Fix #648.