### PR TITLE
chore(ci): make lighthouse work in PR from forks

### DIFF
--- a/.github/workflows/lighthouse-pr-comment.yml
+++ b/.github/workflows/lighthouse-pr-comment.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_run:
+    workflows: [lighthouse]
+    types: [completed]
+
+jobs:
+  lighthouse-pr-comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: lighthouse-pr-comment
+
+      - id: pr_number
+        run: |
+          export PR_NUM=$(ls lighthouse-pr-comment-*.txt | sed -n 's/lighthouse-pr-comment-\(.*\).txt/\1/p')
+          echo "{pr_num}={$PR_NUM}" >> $GITHUB_OUTPUT
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr_number.outputs.pr_num }}
+          path: lighthouse-pr-comment-${{ steps.pr_number.outputs.pr_num }}.txt

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,3 +1,7 @@
+# Don't change the name, it's used in lighthouse-pr-comment.yml
+# to detect the end of this workflow
+name: lighthouse
+
 on:
   pull_request:
 
@@ -31,11 +35,12 @@ jobs:
         env:
           MANIFEST: ${{ steps.lighthouse_audit.outputs.manifest }}
           LINKS: ${{ steps.lighthouse_audit.outputs.links }}
+          PR: ${{ github.event.number }}
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const manifest = JSON.parse(process.env.MANIFEST)
             const links = JSON.parse(process.env.LINKS)
+            const pr = process.env.PR
 
             console.log('Raw output:\n', manifest, '\n', links)
 
@@ -72,8 +77,13 @@ jobs:
                           [${score(result.summary.seo)}](## "SEO") ${result.summary.seo}`
                 })
             ].join('\n')
-            core.setOutput("comment", comment)
-      - uses: marocchino/sticky-pull-request-comment@v2
+
+            const fs = require('fs')
+            fs.writeFileSync(`lighthouse-pr-comment-${pr}.txt`, comment)
+
+      - uses: actions/upload-artifact@v3
         with:
-          message: |
-            ${{ steps.format_lighthouse_score.outputs.comment }}
+          name: lighthouse-pr-comment
+          path: lighthouse-pr-comment-${{ github.event.number }}.txt
+          # Don't need the full default retention of 90 days.
+          retention-days: 3


### PR DESCRIPTION
GitHub pull_request workflows are run within the context of the forked
repo and they can't comment on they own PR.

Using pull_request_target would be a security hole since we need to run
PR-provided arbitrary code to build the site.

The only viable option is `workflow_run` that detect when the
Lighthouse job has finished, as it is run in the context of the parent
repo.

That's extremely convoluted and not ideal because it doesn't even
provide full protection (see below), but it's a GitHub limitation
that needs to be fixed on their side with something like a
new 'comment-write' permission on ephemeral tokens.

There's still a way for a malicious PR to be annoying by
commenting on other PRs but it's not a security issue

Fix https://github.com/italia/designers.italia.it/issues/530.