### PR TITLE
fix: svg a11y markup

### DIFF
--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -21,7 +21,7 @@ const Icon = ({
 		+ `${addonClasses ? ' '+addonClasses : ''}`
 
 	return(
-		<svg className={styles} aria-hidden={hidden} aria-label={ariaLabel}>
+		<svg role="img" className={styles} aria-hidden={hidden} aria-label={ariaLabel}>
 			<use href={`/svg/${icon}`}></use>
 		</svg>
 	)

--- a/src/components/nav-sidebar/nav-sidebar.js
+++ b/src/components/nav-sidebar/nav-sidebar.js
@@ -85,7 +85,7 @@ const NavSidebar = ({
             <button className={linksStyle} data-bs-target={"#collapseNav-"+index} data-bs-toggle="collapse" aria-expanded={expandSublinks} aria-controls={"collapseNav-"+index}>
               <span className="list-item-title-icon-wrapper list-item-title-icon-wrapper d-flex justify-content-between align-items-center">
                 <span>{item.label}</span>
-                <svg className="icon icon-sm icon-primary right" aria-hidden="true"><use href="/svg/sprites.svg#it-expand"></use></svg>
+                <svg role="img" className="icon icon-sm icon-primary right" aria-hidden="true"><use href="/svg/sprites.svg#it-expand"></use></svg>
               </span>
             </button>
             <ul className={subStyles} id={"collapseNav-"+index}>
@@ -165,7 +165,7 @@ const NavSidebar = ({
               </button>
             </div>
             <a className="it-back-button" href="#" role="button">
-              <svg className="icon icon-sm icon-primary align-top">
+              <svg role="img" className="icon icon-sm icon-primary align-top">
                 <use href="/svg/sprites.svg#it-chevron-left"></use>
               </svg>
               <span>{backLabel}</span>

--- a/src/components/numbers/numbers.js
+++ b/src/components/numbers/numbers.js
@@ -23,6 +23,7 @@ const Numbers = ({
               icon={num.icon}
               size="lg"
               addonClasses="mt-1 me-2"
+              hidden
             />
             <div className="number font-monospace fw-normal display-1">{num.number}</div>
           </div>


### PR DESCRIPTION
As reported by @cfabry

@astagi just a reminder: we have to check & review Bootstrap Italia `<SVG>`s maybe they (the icons) are missing a `role="img"` also there. 