### PR TITLE
chore(ci): properly get the Lighthouse artifact

### DIFF
--- a/.github/workflows/lighthouse-pr-comment.yml
+++ b/.github/workflows/lighthouse-pr-comment.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: dawidd6/action-download-artifact@v2
         with:
           name: lighthouse-pr-comment
+          run_id: ${{ github.event.workflow_run.id }}
 
       - id: pr_number
         run: |


### PR DESCRIPTION
`download-artifact` doesn't support getting artifacts from a different workflow
https://github.com/actions/download-artifact/issues/172

Let's use a third party action that does it.

Fix #530.