### PR TITLE
Fix: Kit "Architettura dell'informazione" short description

### DIFF
--- a/src/data/content/risorse-per-progettare/progettare/architettura-dell-informazione.yaml
+++ b/src/data/content/risorse-per-progettare/progettare/architettura-dell-informazione.yaml
@@ -123,7 +123,7 @@ components:
         size: sm
       text: In breve
     text: | #C
-     L’ottimizzazione SEO è possibile grazie a **interventi mirati sui contenuti dei siti web**, migliorarando **la trovabilità da parte degli utenti durante le ricerche online**. Con le risorse del kit potrai **definire e pianificare le attività di ottimizzazione per i motori di ricerca del tuo progetto digitale**.
+     Il kit contiene strumenti operativi che, usati in maniera organica, ti aiutano a progettare un’architettura dell'informazione efficace, per garantire all’utente di **raggiungere i propri obiettivi** in maniera immediata, rapida e intuitiva.
     img: /images/risorse-per-progettare/icons/kit_architettura.svg #I
     alt: "" #C
 

--- a/src/data/content/risorse-per-progettare/progettare/seo.yaml
+++ b/src/data/content/risorse-per-progettare/progettare/seo.yaml
@@ -121,7 +121,7 @@ components:
         size: sm
       text: In breve
     text: | #C
-     L’ottimizzazione SEO è possibile grazie a **interventi mirati sui contenuti dei siti web**, migliorarando **la trovabilità da parte degli utenti durante le ricerche online**. Con le risorse del kit potrai **definire e pianificare le attività di ottimizzazione per i motori di ricerca del tuo progetto digitale**.
+     L’ottimizzazione SEO è possibile grazie a **interventi mirati sui contenuti dei siti web**, rendendoli **più facili da trovare da parte degli utenti durante le ricerche online**. Con le risorse del kit potrai **definire e pianificare le attività di ottimizzazione per i motori di ricerca del tuo progetto digitale**.
     img: /images/risorse-per-progettare/icons/kit_SEO.svg #I
     alt: "" #C
 


### PR DESCRIPTION
The "In breve" short description text for the kit was wrong; I replaced it with the correct one.

During this process, I also noticed a typo + a possibile improvement in the "SEO" kit short description, so I changed it as well.