### PR TITLE
chore: disable the live linting during development

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -360,8 +360,9 @@ module.exports = {
       options: {
         // Gatsby required rules directory
         rulePaths: [gatsbyRequiredRules],
-        // Default settings that may be omitted or customized
-        stages: ["develop"],
+        // re-add "develop" to the stages once https://github.com/italia/designers.italia.it/issues/848
+        // is fixed
+        stages: [""],
         extensions: ["js", "jsx", "ts", "tsx"],
         exclude: ["node_modules", "bower_components", ".cache", "public"],
         // Any additional eslint-webpack-plugin options below


### PR DESCRIPTION
The code is not completly linted yet (#848), so let's disable the check during development.