### PR TITLE
fix: menu column height

### DIFF
--- a/src/components/nav-sidebar/nav-sidebar.scss
+++ b/src/components/nav-sidebar/nav-sidebar.scss
@@ -91,7 +91,7 @@
 @include media-breakpoint-up(lg) {
 
   .menu-column {
-    height: calc(100vh);
+    height: 100%;
     overflow-y: auto;
 	  z-index: auto !important;
   }


### PR DESCRIPTION
Changing the `.menu-column` height fixes the double content scrolling effect.

The menu still stays fix until it reaches the total height of its own content.