### PR TITLE
chore(issue-template): move screenshots hint to the main section

### DIFF
--- a/.github/ISSUE_TEMPLATE/apri-una-segnalazione.it.yaml
+++ b/.github/ISSUE_TEMPLATE/apri-una-segnalazione.it.yaml
@@ -11,44 +11,48 @@ body:
     - label: Ho verificato e non esiste
       required: true
 - type: markdown
-  attributes: 
+  attributes:
     value: "-------"
 - type: textarea
   attributes:
     label: Cosa
     description: |
       Descrivi in modo chiaro e conciso il tema della tua segnalazione indicando il link della pagina o delle pagine interessate.
+
       Per segnalare un bug indica come riprodurlo per passi: es. (1) Vai a '...'; (2) Fai click su '...'; (3) Ora trovi il bug '...'.
-      Per proporre un contributo descrivi la soluzione che immagini, cosa ti aspetti e le eventuali alternative hai già valutato. 
+      Per proporre un contributo descrivi la soluzione che immagini, cosa ti aspetti e le eventuali alternative hai già valutato.
+
+      Puoi anche aggiungere catture di schermo per arricchire la segnalazione.
   validations:
     required: true
 - type: textarea
   attributes:
-    label: Perché 
+    label: Perché
     description: |
-      Spiega perché ritieni rilevante la segnalazione. 
+      Spiega perché ritieni rilevante la segnalazione.
+
       Indica analisi, verifiche e test svolti a supporto (es. dati di analytics, analisi euristiche, test di usabilità, verifiche di accessibilità), se disponibili.
   validations:
     required: true
 - type: textarea
   attributes:
-    label: Contesto 
+    label: Contesto
     description: |
-      Se significative, inserisci informazioni su tipo di dispositivo, sistema operativo, browser. 
-      Puoi anche aggiungere catture di schermo per arricchire la segnalazione.
-      Assicurati di non condividere informazioni personali.   
+      Se significative, inserisci informazioni su tipo di dispositivo, sistema operativo, browser.
+
+      Assicurati di non condividere informazioni personali.
   validations:
     required: false
 - type: textarea
   attributes:
-    label: Altro 
+    label: Altro
     description: |
       Inserisci link a esempi, ricerca, design o codice a corredo della segnalazione, se disponibili.
   validations:
     required: false
 - type: markdown
-  attributes: 
+  attributes:
     value: |
       -------
 
-      [Conosci il modello di contribuzione del design system del Paese?](https://designers.italia.it/design-system/come-contribuire/modello-di-contribuzione/) 
+      [Conosci il modello di contribuzione del design system del Paese?](https://designers.italia.it/design-system/come-contribuire/modello-di-contribuzione/)

--- a/.github/ISSUE_TEMPLATE/open-an-issue.en.yaml
+++ b/.github/ISSUE_TEMPLATE/open-an-issue.en.yaml
@@ -5,49 +5,53 @@ body:
 - type: checkboxes
   attributes:
     label: Does a discussion already exist on the topic you are interested in, or on a similar topic?
-    description: | 
+    description: |
       Please check [issue list](https://github.com/italia/designers.italia.it/issues/). If it exists, participate by posting a comment on the already existing issue.
     options:
     - label: I verified and it doesn't exist
       required: true
 - type: markdown
-  attributes: 
+  attributes:
     value: "-------"
 - type: textarea
   attributes:
     label: What
     description: |
-      Please describe the theme of your issue in a clear and concise manner, and include the link to the page(s) of concern and screenshots. 
-      To report a bug, specify how to reproduce it step by step. E.g. (1) Go to '...'; (2) Click '...'; (3) Notice the bug '...'. 
+      Please describe the theme of your issue in a clear and concise manner, and include the link to the page(s) of concern and screenshots.
+
+      To report a bug, specify how to reproduce it step by step. E.g. (1) Go to '...'; (2) Click '...'; (3) Notice the bug '...'.
       To propose a novel contribution, describe the problem you want to solve and the solution you envision, what you expect, and any alternative solutions you've considered.
+
+      Consider adding screen captures to enhance your report.
   validations:
     required: true
 - type: textarea
   attributes:
-    label: Why 
+    label: Why
     description: |
-      Explain why you consider this report relevant. 
+      Explain why you consider this report relevant.
+
       Highlight any analysis, verifications and tests you've conducted to support your issue or contribution (e.g., data analytics, heuristic analysis, usability tests, accessibility checks), if available.
   validations:
     required: true
 - type: textarea
   attributes:
-    label: Context 
+    label: Context
     description: |
-      If relevant, please provide details on the device type, operating system and browser. 
-      Consider adding screen captures to enhance your report. 
-      Make sure you do not share any personal information in the process.   
+      If relevant, please provide details on the device type, operating system and browser.
+
+      Make sure you do not share any personal information in the process.
   validations:
     required: false
 - type: textarea
   attributes:
-    label: More 
+    label: More
     description: |
       If available, provide links to related examples, research, designs or code.
   validations:
     required: false
 - type: markdown
-  attributes: 
+  attributes:
     value: |
       -------
 


### PR DESCRIPTION
It makes sense to move the screenshots or screencasts to the section where the reporter describes the steps to reproduce the issue