### PR TITLE
feat: way to skip the generation of last modification time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Il sito utilizza l'ultima versione di [Bootstrap Italia](https://italia.github.i
 
 Commenti e proposte relative all'evoluzione del sito e delle risorse può essere fatta aprendo una [nuova issue](https://github.com/italia/designers.italia.it/issues/new), o esplorando le [issues](https://github.com/italia/designers.italia.it/issues) esistenti. Se vuoi contribuire e proporre una modifica, è sufficiente aprire una [pull request](https://github.com/italia/designers.italia.it/pulls).
 
+### ✏️ Content
+
+The site's content is at [src/data/content/](src/data/content/), and whenever a
+file is updated the last modification time is automatically generated.
+
+If you want to update one of those files without altering the displayed last
+modification time, include `(last-update-skip)` somewhere in the commit message.
+
 ## 🚀 Quick start
 
 1.  **Install dependencies.**

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -87,7 +87,16 @@ module.exports = {
         path: `./src/pages/`,
       },
     },
-    `@colliercz/gatsby-transformer-gitinfo`,
+    {
+      resolve: `@colliercz/gatsby-transformer-gitinfo`,
+      options: {
+        include: /\.ya?ml/i,
+        match: {
+          regex: "(last-update-skip)",
+          invert: true,
+        }
+      },
+    },
     {
       resolve: "gatsby-plugin-matomo",
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1922,7 +1922,7 @@
     },
     "node_modules/@colliercz/gatsby-transformer-gitinfo": {
       "version": "1.4.0",
-      "resolved": "git+ssh://git@github.com/CollierCZ/gatsby-transformer-gitinfo.git#b172708a48bc1617126cf7c8d227e97d849cd1c3",
+      "resolved": "git+ssh://git@github.com/CollierCZ/gatsby-transformer-gitinfo.git#cd8030f4f91011c8528db9113cef10be6cd1a8c9",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.21.0",


### PR DESCRIPTION
When using `chore(content-skip)` somewhere in the commit message for commits that change src/data/content/, the last modification time in the generated pages won't be updated.