### PR TITLE
refactor: enable prettier and fix the styling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
     "plugin:jsx-a11y/recommended",
     "airbnb",
     "airbnb/hooks",
-    "prettier"
+    "plugin:prettier/recommended"
   ],
   "parser": "@babel/eslint-parser",
   "parserOptions": {

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,0 @@
-{
-  "singleQuote": true,
-  "arrowParens": "avoid",
-  "endOfLine": "auto"
-}

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,5 @@
 exports.shouldUpdateScroll = ({ routerProps: { location } }) => {
-  if (location.hash === '') {
+  if (location.hash === "") {
     window.scrollTo(0, 0);
     document.scrollingElement.scrollTop = 0;
   }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,40 +1,41 @@
-const path = require('path');
-const { getCrumbLabelUpdates } = require('./scripts/breadcrumbs');
+const path = require("path");
+const { getCrumbLabelUpdates } = require("./scripts/breadcrumbs");
 
 require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
-})
+});
 
 // Get paths of Gatsby's required rules, which as of writing is located at:
 // https://github.com/gatsbyjs/gatsby/tree/fbfe3f63dec23d279a27b54b4057dd611dce74bb/packages/
 // gatsby/src/utils/eslint-rules
 const gatsbyRequiredRules = path.join(
   process.cwd(),
-  'node_modules',
-  'gatsby',
-  'dist',
-  'utils',
-  'eslint-rules'
+  "node_modules",
+  "gatsby",
+  "dist",
+  "utils",
+  "eslint-rules",
 );
 
 module.exports = {
   trailingSlash: "always",
   siteMetadata: {
     siteUrl: `https://designers.italia.it`,
-    title : "Designers Italia",
-    author : "Dipartimento per la trasformazione digitale e AGID",
-    lang : "it",
-    description : "Il punto di riferimento per la progettazione dei servizi pubblici digitali",
-    siteName : "Designers Italia",
-    image : "https://designers.italia.it/assets/icons/logo-it.png",
-    twitterImage : "https://designers.italia.it/assets/icons/logo-it.png",
-    twitterSite : "@DesignersITA",
-    twitterCreator : "Dipartimento per la trasformazione digitale e AGID",
-    themeColor: "#0066cc"
+    title: "Designers Italia",
+    author: "Dipartimento per la trasformazione digitale e AGID",
+    lang: "it",
+    description:
+      "Il punto di riferimento per la progettazione dei servizi pubblici digitali",
+    siteName: "Designers Italia",
+    image: "https://designers.italia.it/assets/icons/logo-it.png",
+    twitterImage: "https://designers.italia.it/assets/icons/logo-it.png",
+    twitterSite: "@DesignersITA",
+    twitterCreator: "Dipartimento per la trasformazione digitale e AGID",
+    themeColor: "#0066cc",
   },
   plugins: [
     {
-      resolve:`gatsby-plugin-breadcrumb`,
+      resolve: `gatsby-plugin-breadcrumb`,
       options: {
         useAutoGen: true,
         crumbLabelUpdates: getCrumbLabelUpdates(),
@@ -43,7 +44,7 @@ module.exports = {
           `**/dev-404-page/**`,
           `**/404/**`,
           `**/404.html`,
-          `**/offline-plugin-app-shell-fallback/**`
+          `**/offline-plugin-app-shell-fallback/**`,
         ],
         trailingSlashes: true,
       },
@@ -63,8 +64,8 @@ module.exports = {
         defaults: {
           formats: ["auto", "webp", "avif"],
           placeholder: "dominantColor", // or blurred ...
-          quality: 70
-        }
+          quality: 70,
+        },
       },
     },
     {
@@ -94,7 +95,7 @@ module.exports = {
         match: {
           regex: "(last-update-skip)",
           invert: true,
-        }
+        },
       },
     },
     {
@@ -337,7 +338,16 @@ module.exports = {
         // List of keys to store and make available in your UI. The values of
         // the keys are taken from the normalizer function below.
         // Default: all fields
-        store: ["id", "template", "relativePath", "path", "title", "description", "tag", "tags"],
+        store: [
+          "id",
+          "template",
+          "relativePath",
+          "path",
+          "title",
+          "description",
+          "tag",
+          "tags",
+        ],
 
         // Function used to map the result from the GraphQL query. This should
         // return an array of items to index in the form of flat objects
@@ -345,23 +355,31 @@ module.exports = {
         // field above (default: 'id'). This is required.
         normalizer: ({ data }) =>
           data.allContent.edges.map((edge) => ({
-              id: edge.node.id,
-              template: edge.node.metadata?.template?.name,
-              relativePath: `/${  edge.node.relativePath}`,
-              tags: edge.node.components?.hero?.kangaroo?.tags,
-              path: `${edge.node.seo?.pathname}`,
-              title: `${edge.node.components?.hero?.title}`,
-              description: `${edge.node.seo?.description}`,
-              tag: `${edge.node.components?.hero?.tag?.label}`,
-              body:  `${edge.node.components?.hero?.subtitle} ${edge.node.components?.hero?.text}`
-                + ` ${edge.node.components?.sectionIntro?.title} ${edge.node.components?.sectionIntro?.text} ${edge.node.components?.sectionIntro?.moreText}`
-                + ` ${  edge.node.components?.sectionsEditorial?.map(s => s.title).join(' ')
-                 } ${  edge.node.components?.sectionsEditorial?.map(s => s.components?.map(c=> c.title)).join(' ')
-                 } ${  edge.node.components?.sectionsEditorial2?.map(s => s.components?.map(c => c.title)).join(' ')
-                 } ${  edge.node.components?.sectionsEditorial?.map(s => s.text).join(' ')
-                 } ${  edge.node.components?.sectionsEditorial?.map(s => s.components?.map(c => c.text)).join(' ')
-                 } ${  edge.node.components?.sectionsEditorial2?.map(s => s.components?.map(c => c.text)).join(' ')}`,
-            })),
+            id: edge.node.id,
+            template: edge.node.metadata?.template?.name,
+            relativePath: `/${edge.node.relativePath}`,
+            tags: edge.node.components?.hero?.kangaroo?.tags,
+            path: `${edge.node.seo?.pathname}`,
+            title: `${edge.node.components?.hero?.title}`,
+            description: `${edge.node.seo?.description}`,
+            tag: `${edge.node.components?.hero?.tag?.label}`,
+            body:
+              `${edge.node.components?.hero?.subtitle} ${edge.node.components?.hero?.text}` +
+              ` ${edge.node.components?.sectionIntro?.title} ${edge.node.components?.sectionIntro?.text} ${edge.node.components?.sectionIntro?.moreText}` +
+              ` ${edge.node.components?.sectionsEditorial
+                ?.map((s) => s.title)
+                .join(" ")} ${edge.node.components?.sectionsEditorial
+                ?.map((s) => s.components?.map((c) => c.title))
+                .join(" ")} ${edge.node.components?.sectionsEditorial2
+                ?.map((s) => s.components?.map((c) => c.title))
+                .join(" ")} ${edge.node.components?.sectionsEditorial
+                ?.map((s) => s.text)
+                .join(" ")} ${edge.node.components?.sectionsEditorial
+                ?.map((s) => s.components?.map((c) => c.text))
+                .join(" ")} ${edge.node.components?.sectionsEditorial2
+                ?.map((s) => s.components?.map((c) => c.text))
+                .join(" ")}`,
+          })),
       },
     },
     {
@@ -381,8 +399,8 @@ module.exports = {
     // This must be the last plugin in the array
     `gatsby-plugin-meta-redirect`,
   ],
-  pathPrefix: '/',
+  pathPrefix: "/",
   flags: {
-    DEV_SSR: true
+    DEV_SSR: true,
   },
-}
+};

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,20 +1,20 @@
 /* eslint-disable no-console */ // console.log is ok here for progress reporting
 
-const { createRemoteFileNode, } = require("gatsby-source-filesystem")
+const { createRemoteFileNode } = require("gatsby-source-filesystem");
 
-const jsYaml = require(`js-yaml`)
+const jsYaml = require(`js-yaml`);
 
-const _ = require("lodash")
-const path = require("path")
-const express = require('express')
-const { fetchDataFiles } = require('./server/fetchDataFiles')
-const { findValues } = require('./server/utils/findValues')
+const _ = require("lodash");
+const path = require("path");
+const express = require("express");
+const { fetchDataFiles } = require("./server/fetchDataFiles");
+const { findValues } = require("./server/utils/findValues");
 
-const isRemoteAsset = (assetPath) => assetPath.startsWith('http')
+const isRemoteAsset = (assetPath) => assetPath.startsWith("http");
 
 exports.onCreateDevServer = ({ app }) => {
-  app.use(express.static('public'))
-}
+  app.use(express.static("public"));
+};
 
 exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
   if (stage === "build-html" || stage === "develop-html") {
@@ -27,47 +27,44 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
           },
         ],
       },
-    })
+    });
   }
-}
+};
 
 exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions
+  const { createTypes } = actions;
 
   createTypes(`
     type RemoteAsset implements Node {
       source: String
       file: File @link(from: "fields.localFile")
     }
-  `)
-}
+  `);
+};
 
-exports.sourceNodes = async ({
-  actions: { createNode },
-}) => {
-
+exports.sourceNodes = async ({ actions: { createNode } }) => {
   // assets import in graphQL for gatsby-plugin-image
-  const dataFiles = fetchDataFiles()
-  const assets = [...new Set(findValues(dataFiles, 'img'))] // new Set removes duplicates
+  const dataFiles = fetchDataFiles();
+  const assets = [...new Set(findValues(dataFiles, "img"))]; // new Set removes duplicates
 
   assets.forEach((asset, idx) => {
     if (isRemoteAsset(asset)) {
       const data = {
-        source: asset
-      }
+        source: asset,
+      };
       createNode({
         ...data,
         id: `asset-${idx}`,
         parent: null,
         children: [],
         internal: {
-          type: 'RemoteAsset',
+          type: "RemoteAsset",
           // contentDigest: createContentDigest(data),
         },
-      })
+      });
     }
-  })
-}
+  });
+};
 
 exports.onCreateNode = async ({
   node,
@@ -77,27 +74,26 @@ exports.onCreateNode = async ({
   loadNodeContent,
   getCache,
 }) => {
-  const CONTENT_NODE_TYPE = "Content"
+  const CONTENT_NODE_TYPE = "Content";
 
   if (node.internal.type === "RemoteAsset") {
     const fileNode = await createRemoteFileNode({
       url: node.source,
       parentNodeId: node.id,
       createNode,
-      createNodeId,// `${node.unique_identifier_prop}-assets-${index}`,
+      createNodeId, // `${node.unique_identifier_prop}-assets-${index}`,
       getCache,
-    })
+    });
     if (fileNode) {
-      createNodeField({ node, name: "localFile", value: fileNode.id })
+      createNodeField({ node, name: "localFile", value: fileNode.id });
     }
   } else if (
     node.internal.type === "File" &&
     node.sourceInstanceName === "content" &&
-    (node.extension === 'yaml' ||
-      node.extension === 'yml')
+    (node.extension === "yaml" || node.extension === "yml")
   ) {
-    const content = await loadNodeContent(node)
-    const parsedContent = jsYaml.load(content)
+    const content = await loadNodeContent(node);
+    const parsedContent = jsYaml.load(content);
 
     const contentNode = {
       ...parsedContent,
@@ -108,20 +104,18 @@ exports.onCreateNode = async ({
         type: CONTENT_NODE_TYPE,
         contentDigest: createContentDigest(node),
       },
-      relativePath: node.relativePath.replace(/(\.yaml$|\.yml$)/i, ''),
+      relativePath: node.relativePath.replace(/(\.yaml$|\.yml$)/i, ""),
     };
 
-    createNode(contentNode)
-    createParentChildLink({ parent: node, child: contentNode })
+    createNode(contentNode);
+    createParentChildLink({ parent: node, child: contentNode });
   }
-}
-
+};
 
 exports.createPages = async ({ graphql, actions }) => {
-
   // tags
-  const { createPage } = actions
-  const tagTemplate = path.resolve("src/templates/tag.js")
+  const { createPage } = actions;
+  const tagTemplate = path.resolve("src/templates/tag.js");
   const tags = await graphql(`
     {
       tagsGroup: allContent {
@@ -130,46 +124,52 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       }
     }
-  `
-  )
-  tags.data.tagsGroup.group.forEach(tag => {
-    console.log(`Creating tag page: ${tag.fieldValue}`)
+  `);
+  tags.data.tagsGroup.group.forEach((tag) => {
+    console.log(`Creating tag page: ${tag.fieldValue}`);
     createPage({
       path: `/argomenti/${_.kebabCase(tag.fieldValue)}/`,
       component: tagTemplate,
       context: {
         tag: tag.fieldValue,
-      }
-    })
-  })
+      },
+    });
+  });
   // tagsDesignSystem
-  const tagDesignSystemTemplate = path.resolve("src/templates/design-system-index-components-tags.js")
+  const tagDesignSystemTemplate = path.resolve(
+    "src/templates/design-system-index-components-tags.js",
+  );
   const tagsDesignSystem = await graphql(`
     {
       tagsDesignSystemGroup: allContent {
-        group(field: { components: { hero: { kangaroo: { tagsDesignSystem: SELECT } } } }) {
+        group(
+          field: {
+            components: { hero: { kangaroo: { tagsDesignSystem: SELECT } } }
+          }
+        ) {
           fieldValue
         }
       }
     }
-  `
-  )
-  tagsDesignSystem.data.tagsDesignSystemGroup.group.forEach(tag => {
-    console.log(`Creating tag page: ${tag.fieldValue}`)
+  `);
+  tagsDesignSystem.data.tagsDesignSystemGroup.group.forEach((tag) => {
+    console.log(`Creating tag page: ${tag.fieldValue}`);
     createPage({
-      path: `/design-system/componenti/utili-per/${_.kebabCase(tag.fieldValue)}/`,
+      path: `/design-system/componenti/utili-per/${_.kebabCase(
+        tag.fieldValue,
+      )}/`,
       component: tagDesignSystemTemplate,
       context: {
         tag: tag.fieldValue,
-      }
-    })
-  })
+      },
+    });
+  });
 
   // redirs
-  const { createRedirect } = actions
+  const { createRedirect } = actions;
   const redirs = await graphql(`
     {
-      allContent (filter: { metadata: { redirect_from: { ne: null } } }) {
+      allContent(filter: { metadata: { redirect_from: { ne: null } } }) {
         edges {
           node {
             seo {
@@ -182,14 +182,13 @@ exports.createPages = async ({ graphql, actions }) => {
         }
       }
     }
-  `
-  )
+  `);
   redirs.data.allContent.edges.forEach((edge) => {
-    const { node } = edge
+    const { node } = edge;
     node.metadata.redirect_from.forEach((fromPath) => {
-      const toPath = edge.node.seo.pathname
-      console.log(`Creating redirect: ${fromPath} -> ${toPath}...`)
-      createRedirect({ fromPath, toPath, })
-    })
-  })
-}
+      const toPath = edge.node.seo.pathname;
+      console.log(`Creating redirect: ${fromPath} -> ${toPath}...`);
+      createRedirect({ fromPath, toPath });
+    });
+  });
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,3 +1,3 @@
 exports.onRenderBody = ({ setHtmlAttributes }) => {
-  setHtmlAttributes({ lang: "it" })
-}
+  setHtmlAttributes({ lang: "it" });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.32.2",
         "eslint-webpack-plugin": "^4.0.1",
         "gatsby-plugin-eslint": "^4.0.4",
@@ -3986,6 +3987,62 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
       "license": "MIT",
@@ -5695,6 +5752,15 @@
         "node": ">8.0.0"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "license": "MIT",
@@ -5911,6 +5977,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -5994,6 +6072,21 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "license": "MIT"
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -6262,7 +6355,8 @@
     },
     "node_modules/classnames": {
       "version": "2.3.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -7229,6 +7323,150 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-browser/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-browser/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "license": "MIT",
@@ -8095,6 +8333,35 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.32.2",
       "license": "MIT",
@@ -8626,14 +8893,21 @@
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
       "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "license": "MIT",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -12159,6 +12433,39 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-invalid-path": {
@@ -15950,6 +16257,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -17121,6 +17440,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -18268,6 +18602,28 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/table": {
       "version": "6.8.1",
       "license": "BSD-3-Clause",
@@ -18440,6 +18796,18 @@
       "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tmp": {
@@ -18859,6 +19227,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-webpack-plugin": "^4.0.1",
     "gatsby-plugin-eslint": "^4.0.4",

--- a/scripts/breadcrumbs.js
+++ b/scripts/breadcrumbs.js
@@ -1,30 +1,32 @@
-const yaml = require('js-yaml');
-const fs = require('fs');
-const {walk} = require('./utils');
+const yaml = require("js-yaml");
+const fs = require("fs");
+const { walk } = require("./utils");
 
 const getCrumbLabelUpdates = () => {
   const paths = [];
-  walk('./src/data/', (path) => {
-    if (path.endsWith('.yaml')) {
-      const doc = yaml.load(fs.readFileSync(path, 'utf8'));
-      if(doc.seo && doc.seo.pathname) {
-        const found = paths.find(element => element.pathname === doc.seo.pathname);
+  walk("./src/data/", (path) => {
+    if (path.endsWith(".yaml")) {
+      const doc = yaml.load(fs.readFileSync(path, "utf8"));
+      if (doc.seo && doc.seo.pathname) {
+        const found = paths.find(
+          (element) => element.pathname === doc.seo.pathname,
+        );
         if (!found) {
           paths.push({
-            pathname: doc.seo.pathname.replace(/\/+$/, ''),
-            crumbLabel: doc.seo.name.split(" -")[0]
-          })
+            pathname: doc.seo.pathname.replace(/\/+$/, ""),
+            crumbLabel: doc.seo.name.split(" -")[0],
+          });
         }
       }
     }
-    paths.push({ 
+    paths.push({
       pathname: "/design-system/componenti/utili-per",
-      crumbLabel: "Utili per"
-    })
+      crumbLabel: "Utili per",
+    });
   });
-  return paths
+  return paths;
 };
 
 module.exports = {
-    getCrumbLabelUpdates
-}
+  getCrumbLabelUpdates,
+};

--- a/scripts/download-examples.js
+++ b/scripts/download-examples.js
@@ -1,55 +1,52 @@
 /* eslint-disable no-console */ // console.log is ok here for progress reporting
 
-const request = require('superagent');
-const AdmZip = require('adm-zip');
-const fs = require('fs');
-const path = require('path');
+const request = require("superagent");
+const AdmZip = require("adm-zip");
+const fs = require("fs");
+const path = require("path");
 
+const DEST_DIR = path.join("src", "data", "components_json");
 
-const DEST_DIR = path.join("src", "data", "components_json")
+async function downloadExamples(context) {
+  const href = "https://github.com/italia/bootstrap-italia/archive";
+  const zipFile = "main.zip";
 
-async function downloadExamples (context) {
+  const source = `${href}/${zipFile}`;
 
-    const href = 'https://github.com/italia/bootstrap-italia/archive';
-    const zipFile = 'main.zip';
-
-    const source = `${href}/${zipFile}`;
-
-    return new Promise((resolve, reject) => {
-        request.get(source)
-            .on('error', (error) => {
-                reject(error);
-            })
-            .pipe(fs.createWriteStream(zipFile))
-            .on('finish', () => {
-                console.log('✅ Finished downloading');
-                const zip = new AdmZip(zipFile);
-                console.log('📑 Extracting json');
-                fs.mkdirSync(path.join(DEST_DIR, context), { recursive: true })
-                const zipEntries = zip.getEntries();
-                zipEntries.forEach((zipEntry) => {
-                    if (zipEntry.entryName.match(/.*\/api\/.*.json/)) {
-                        const newFolder = path.join(
-                            DEST_DIR, context,
-                            path.dirname(zipEntry.entryName).split(path.sep).pop(),
-                        )
-                        fs.mkdirSync(newFolder, { recursive: true })
-                        fs.writeFileSync(
-                            path.join(
-                                newFolder,
-                                path.parse(zipEntry.entryName).base
-                            ),
-                            zipEntry.getData().toString("utf8"),
-                            'utf-8'
-                        )
-                    }
-                });
-                fs.unlinkSync(zipFile);
-                resolve()
-            });
-    })
+  return new Promise((resolve, reject) => {
+    request
+      .get(source)
+      .on("error", (error) => {
+        reject(error);
+      })
+      .pipe(fs.createWriteStream(zipFile))
+      .on("finish", () => {
+        console.log("✅ Finished downloading");
+        const zip = new AdmZip(zipFile);
+        console.log("📑 Extracting json");
+        fs.mkdirSync(path.join(DEST_DIR, context), { recursive: true });
+        const zipEntries = zip.getEntries();
+        zipEntries.forEach((zipEntry) => {
+          if (zipEntry.entryName.match(/.*\/api\/.*.json/)) {
+            const newFolder = path.join(
+              DEST_DIR,
+              context,
+              path.dirname(zipEntry.entryName).split(path.sep).pop(),
+            );
+            fs.mkdirSync(newFolder, { recursive: true });
+            fs.writeFileSync(
+              path.join(newFolder, path.parse(zipEntry.entryName).base),
+              zipEntry.getData().toString("utf8"),
+              "utf-8",
+            );
+          }
+        });
+        fs.unlinkSync(zipFile);
+        resolve();
+      });
+  });
 }
 
 module.exports = {
-    downloadExamples
-}
+  downloadExamples,
+};

--- a/scripts/generate-examples.js
+++ b/scripts/generate-examples.js
@@ -1,41 +1,46 @@
-const path = require('path');
-const fs = require('fs');
-const slugify = require('slugify')
-const Mustache = require('mustache');
-const { searchInDir } = require("./utils")
-const bsiData = require("../node_modules/bootstrap-italia/package.json")
+const path = require("path");
+const fs = require("fs");
+const slugify = require("slugify");
+const Mustache = require("mustache");
+const { searchInDir } = require("./utils");
+const bsiData = require("../node_modules/bootstrap-italia/package.json");
 
-
-const SEARCH_DIR = path.join("src", "data", "components_json")
-const EXAMPLES_DIR = path.join("static", "examples")
-const HTML_TEMPLATE = fs.readFileSync(path.join(EXAMPLES_DIR, "templates", "base.html"), 'utf-8')
+const SEARCH_DIR = path.join("src", "data", "components_json");
+const EXAMPLES_DIR = path.join("static", "examples");
+const HTML_TEMPLATE = fs.readFileSync(
+  path.join(EXAMPLES_DIR, "templates", "base.html"),
+  "utf-8",
+);
 
 function generateExamples(context) {
-    const jsonFiles = searchInDir(SEARCH_DIR, ".json")
-    for (const jsonFile of jsonFiles) {
-        const parsedJson = JSON.parse(fs.readFileSync(jsonFile, 'utf-8'))
-        const componentFolder = path.join(
-            EXAMPLES_DIR,
-            context,
-            path.dirname(jsonFile).split(path.sep).pop(),
-            path.parse(jsonFile).base.replace(".json", "")
-        )
-        fs.mkdirSync(componentFolder, { recursive: true })
-        for (const example of parsedJson) {
-            const filePath = `${path.join(componentFolder, slugify(example.name).toLowerCase())}.html`
-            fs.writeFileSync(
-                filePath,
-                Mustache.render(HTML_TEMPLATE, {
-                    code: example.content,
-                    name: example.name,
-                    bsiversion: bsiData.version
-                }),
-                'utf-8'
-            )
-        }
+  const jsonFiles = searchInDir(SEARCH_DIR, ".json");
+  for (const jsonFile of jsonFiles) {
+    const parsedJson = JSON.parse(fs.readFileSync(jsonFile, "utf-8"));
+    const componentFolder = path.join(
+      EXAMPLES_DIR,
+      context,
+      path.dirname(jsonFile).split(path.sep).pop(),
+      path.parse(jsonFile).base.replace(".json", ""),
+    );
+    fs.mkdirSync(componentFolder, { recursive: true });
+    for (const example of parsedJson) {
+      const filePath = `${path.join(
+        componentFolder,
+        slugify(example.name).toLowerCase(),
+      )}.html`;
+      fs.writeFileSync(
+        filePath,
+        Mustache.render(HTML_TEMPLATE, {
+          code: example.content,
+          name: example.name,
+          bsiversion: bsiData.version,
+        }),
+        "utf-8",
+      );
     }
+  }
 }
 
 module.exports = {
-    generateExamples
-}
+  generateExamples,
+};

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-console */ // console.log is ok here for progress reporting
 
-const {generateExamples} = require("./generate-examples.js")
-const {downloadExamples} = require("./download-examples.js")
+const { generateExamples } = require("./generate-examples.js");
+const { downloadExamples } = require("./download-examples.js");
 
 const main = async () => {
-    console.log("⤵️ Downloading examples...")
-    await downloadExamples('bsi')
-    console.log("✅ Done")
-    console.log("🧵 Generating examples...")
-    generateExamples('bsi')
-    console.log("✅ Done")
-}
+  console.log("⤵️ Downloading examples...");
+  await downloadExamples("bsi");
+  console.log("✅ Done");
+  console.log("🧵 Generating examples...");
+  generateExamples("bsi");
+  console.log("✅ Done");
+};
 
-main()
+main();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,36 +1,37 @@
-const path = require('path');
-const fs = require('fs');
+const path = require("path");
+const fs = require("fs");
 
-function searchInDir(startPath, filter, subfolders=true) {
-    if (!fs.existsSync(startPath)) {
-        throw Error("No dir ", startPath);
+function searchInDir(startPath, filter, subfolders = true) {
+  if (!fs.existsSync(startPath)) {
+    throw Error("No dir ", startPath);
+  }
+  const files = fs.readdirSync(startPath);
+  let collection = [];
+  for (const element of files) {
+    const filename = path.join(startPath, element);
+    if (subfolders && fs.lstatSync(filename).isDirectory()) {
+      collection = collection.concat(searchInDir(filename, filter, subfolders));
+    } else if (filename.endsWith(filter)) {
+      collection.push(filename);
     }
-    const files = fs.readdirSync(startPath);
-    let collection = []
-    for (const element of files) {
-        const filename = path.join(startPath, element);
-        if (subfolders && fs.lstatSync(filename).isDirectory()) {
-            collection = collection.concat(searchInDir(filename, filter, subfolders))
-        } else if (filename.endsWith(filter)) {
-            collection.push(filename);
-        };
-    };
-    return collection;
-};
+  }
+  return collection;
+}
 
 function walk(dir, callback) {
-    const files = fs.readdirSync(dir)
-    files.forEach((file) => {
-        const filepath = path.join(dir, file);
-        const stats = fs.statSync(filepath);
-        if (stats.isDirectory()) {
-            walk(filepath, callback);
-        } else if (stats.isFile()) {
-            callback(filepath, stats);
-        }
-    });
+  const files = fs.readdirSync(dir);
+  files.forEach((file) => {
+    const filepath = path.join(dir, file);
+    const stats = fs.statSync(filepath);
+    if (stats.isDirectory()) {
+      walk(filepath, callback);
+    } else if (stats.isFile()) {
+      callback(filepath, stats);
+    }
+  });
 }
 
 module.exports = {
-    searchInDir, walk
-}
+  searchInDir,
+  walk,
+};

--- a/server/fetchDataFiles.js
+++ b/server/fetchDataFiles.js
@@ -1,16 +1,16 @@
-const yaml = require('js-yaml')
-const fs = require('fs')
-const glob = require('glob')
+const yaml = require("js-yaml");
+const fs = require("fs");
+const glob = require("glob");
 
-const FILE_DATA_EXT = 'yaml'
+const FILE_DATA_EXT = "yaml";
 
 exports.fetchDataFiles = () => {
-  const files = glob.sync(`${__dirname  }/../src/**/*.${  FILE_DATA_EXT}`)
+  const files = glob.sync(`${__dirname}/../src/**/*.${FILE_DATA_EXT}`);
 
-  const result = {}
+  const result = {};
   for (const filePath of files) {
-    result[filePath] = yaml.load(fs.readFileSync(filePath, 'utf8'))
+    result[filePath] = yaml.load(fs.readFileSync(filePath, "utf8"));
   }
 
-  return result
-}
+  return result;
+};

--- a/server/utils/findValues.js
+++ b/server/utils/findValues.js
@@ -1,5 +1,5 @@
 const findValuesHelper = (obj, key, list) => {
-  if (!obj) return list
+  if (!obj) return list;
 
   let originalList = list;
 
@@ -13,18 +13,18 @@ const findValuesHelper = (obj, key, list) => {
     return originalList;
   }
 
-  if (obj[key]) list.push(obj[key])
+  if (obj[key]) list.push(obj[key]);
 
-  if ((typeof obj === "object") && (obj !== null)) {
-    const children = Object.keys(obj)
+  if (typeof obj === "object" && obj !== null) {
+    const children = Object.keys(obj);
     if (children.length > 0) {
       for (const element of children) {
-        originalList = list.concat(findValuesHelper(obj[element], key, []))
+        originalList = list.concat(findValuesHelper(obj[element], key, []));
       }
     }
   }
 
   return originalList;
-}
+};
 
-exports.findValues = (obj, key) => findValuesHelper(obj, key, [])
+exports.findValues = (obj, key) => findValuesHelper(obj, key, []);

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -1,15 +1,13 @@
-import * as React from "react"
+import * as React from "react";
 
-import ImageResponsive from "../image-responsive/image-responsive"
+import ImageResponsive from "../image-responsive/image-responsive";
 
-function Avatar({
-	size,
-	img,
-	alt
-}) {
-	return (
-		<div className={`avatar ${size ? `size-${size}` : undefined}`}><ImageResponsive src={img} alt={alt}/></div>
-	)
+function Avatar({ size, img, alt }) {
+  return (
+    <div className={`avatar ${size ? `size-${size}` : undefined}`}>
+      <ImageResponsive src={img} alt={alt} />
+    </div>
+  );
 }
 
-export default Avatar
+export default Avatar;

--- a/src/components/back-to-top/back-to-top.js
+++ b/src/components/back-to-top/back-to-top.js
@@ -1,24 +1,30 @@
-import React, { useEffect } from "react"
+import React, { useEffect } from "react";
 
-import { BackToTop } from "bootstrap-italia"
-import Icon from "../icon/icon"
+import { BackToTop } from "bootstrap-italia";
+import Icon from "../icon/icon";
 
-function BackToTopEl({ positionTop, scrollLimit, duration, easing, ariaLabel }) {
+function BackToTopEl({
+  positionTop,
+  scrollLimit,
+  duration,
+  easing,
+  ariaLabel,
+}) {
   useEffect(() => {
     // eslint-disable-next-line no-new
-    new BackToTop(document.getElementById('backToTop'), {
+    new BackToTop(document.getElementById("backToTop"), {
       positionTop,
       scrollLimit,
       duration,
       easing,
-    })
+    });
   });
   return (
     // eslint-disable-next-line jsx-a11y/anchor-is-valid
     <a href="#" aria-label={ariaLabel} className="back-to-top" id="backToTop">
-      <Icon icon="sprites.svg#it-arrow-up" color="light"/>
+      <Icon icon="sprites.svg#it-arrow-up" color="light" />
     </a>
-  )
+  );
 }
 
-export default BackToTopEl
+export default BackToTopEl;

--- a/src/components/banner-text-cta/banner-text-cta.js
+++ b/src/components/banner-text-cta/banner-text-cta.js
@@ -1,46 +1,43 @@
-import React from "react"
-import SimpleCta from "../simple-cta/simple-cta"
-import "./banner-text-cta.scss"
+import React from "react";
+import SimpleCta from "../simple-cta/simple-cta";
+import "./banner-text-cta.scss";
 
-function BannerTextCta({
-  id,
-  title,
-  background,
-  ctas,
-  children
-}) {
+function BannerTextCta({ id, title, background, ctas, children }) {
+  const baseStyle = "banner-text-cta";
+  const styles = background ? `${baseStyle} bg-${background}` : baseStyle;
 
-const baseStyle = 'banner-text-cta';
-const styles = background ? `${baseStyle} bg-${background}` : baseStyle;
-
-let ctaItems
+  let ctaItems;
 
   if (ctas) {
-    ctaItems = ctas.map((item,index) => (
-        // eslint-disable-next-line react/jsx-props-no-spreading, react/no-array-index-key
-        <SimpleCta {...item} key={`cta-${index}`}/>
-      ))
+    ctaItems = ctas.map((item, index) => (
+      // eslint-disable-next-line react/jsx-props-no-spreading, react/no-array-index-key
+      <SimpleCta {...item} key={`cta-${index}`} />
+    ));
   }
 
-  return(
+  return (
     <section className={styles} aria-labelledby={id}>
       <div className="container-xxl">
         <div className="row">
           <div className="col-12 /**/ g-0">
             <div className="banner-text-cta-content px-3 py-5 px-lg-0 px-lg-5 py-lg-6">
               <div className="text-zone">
-                <h2 className="mb-5" id={id}>{title}</h2>
+                <h2 className="mb-5" id={id}>
+                  {title}
+                </h2>
               </div>
               {children}
               <div className="cta-zone">
-                {ctaItems && <div className="ctas mt-4 d-md-flex">{ctaItems}</div>}
+                {ctaItems && (
+                  <div className="ctas mt-4 d-md-flex">{ctaItems}</div>
+                )}
               </div>
             </div>
           </div>
         </div>
       </div>
     </section>
-  )
+  );
 }
 
-export default BannerTextCta
+export default BannerTextCta;

--- a/src/components/breadcrumbs/breadcrumbs.js
+++ b/src/components/breadcrumbs/breadcrumbs.js
@@ -1,28 +1,28 @@
-import React from "react"
+import React from "react";
 
-import { Breadcrumb } from "gatsby-plugin-breadcrumb"
-import 'gatsby-plugin-breadcrumb/gatsby-plugin-breadcrumb.css'
+import { Breadcrumb } from "gatsby-plugin-breadcrumb";
+import "gatsby-plugin-breadcrumb/gatsby-plugin-breadcrumb.css";
 
-import './breadcrumbs.scss'
+import "./breadcrumbs.scss";
 
-function Breadcrumbs({
-  pageContext,
-  crumbLabel,
-}) {
-
+function Breadcrumbs({ pageContext, crumbLabel }) {
   const {
     breadcrumb: { crumbs },
-  } = pageContext
+  } = pageContext;
 
   return (
     <div>
       {crumbLabel ? (
-        <Breadcrumb crumbs={crumbs} crumbLabel={crumbLabel} crumbSeparator=" > " />
+        <Breadcrumb
+          crumbs={crumbs}
+          crumbLabel={crumbLabel}
+          crumbSeparator=" > "
+        />
       ) : (
         <Breadcrumb crumbs={crumbs} crumbSeparator=" > " />
       )}
     </div>
-  )
+  );
 }
 
-export default Breadcrumbs
+export default Breadcrumbs;

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -1,80 +1,103 @@
-import * as React from "react"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import './button.scss'
+import * as React from "react";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import "./button.scss";
 
 function Button({
-	url,
-	type,
-	size,
-	id,
-	label,				// if data is yaml
-	btnStyle,         // primary,secondary,outline-primary,outline-secondary,success,warning,danger,info,dropdown
-	customStyle,
-	addonStyle,
-	role,   	         // button role for link <a>
-	disabled,         // true,no prop
-	iconLeft,         // icon in left position (component Icon)
-	iconRight,			 // icon in right position  (component Icon)
-	icon,
-	iconRounded,
-	ariaLabel,        // for buttons icon only, text for screen reader
-	ariaControls,     // id for menu opened by button
-	ariaExpanded,     // true / no prop
-	dataBsToggle,	   // navbarcollapsible,dropdown
-	children,
-	blank,
-	title,
+  url,
+  type,
+  size,
+  id,
+  label, // if data is yaml
+  btnStyle, // primary,secondary,outline-primary,outline-secondary,success,warning,danger,info,dropdown
+  customStyle,
+  addonStyle,
+  role, // button role for link <a>
+  disabled, // true,no prop
+  iconLeft, // icon in left position (component Icon)
+  iconRight, // icon in right position  (component Icon)
+  icon,
+  iconRounded,
+  ariaLabel, // for buttons icon only, text for screen reader
+  ariaControls, // id for menu opened by button
+  ariaExpanded, // true / no prop
+  dataBsToggle, // navbarcollapsible,dropdown
+  children,
+  blank,
+  title,
   onClick,
 }) {
-	let iconRendered
-	const btnStyles = `${customStyle ? '' : 'btn'}${
-		size ? ` btn-${size}` : ''}${
-		btnStyle ? ` btn-${btnStyle}` : ''}${
-		disabled ? ' disabled' : ''}${
-		(iconLeft || (iconRight && !dataBsToggle)) ? ' btn-icon' : ''}${
-		customStyle || ''}${
-		addonStyle ? ` ${addonStyle}` : ''
-	}`;
+  let iconRendered;
+  const btnStyles = `${customStyle ? "" : "btn"}${size ? ` btn-${size}` : ""}${
+    btnStyle ? ` btn-${btnStyle}` : ""
+  }${disabled ? " disabled" : ""}${
+    iconLeft || (iconRight && !dataBsToggle) ? " btn-icon" : ""
+  }${customStyle || ""}${addonStyle ? ` ${addonStyle}` : ""}`;
 
-	let iconRender
-	if (icon) {
-		// eslint-disable-next-line react/jsx-props-no-spreading
-		iconRender = <Icon {...icon}/>
-	}
+  let iconRender;
+  if (icon) {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    iconRender = <Icon {...icon} />;
+  }
 
-	if (label) {
-		// eslint-disable-next-line no-param-reassign
-		children = label
-	}
+  if (label) {
+    // eslint-disable-next-line no-param-reassign
+    children = label;
+  }
 
-	// rounded icon wrapper
-	if (iconRounded) {
-		iconRendered = <span className="rounded-icon">{iconRender}</span>
-	}else{
-		iconRendered = iconRender
-	}
+  // rounded icon wrapper
+  if (iconRounded) {
+    iconRendered = <span className="rounded-icon">{iconRender}</span>;
+  } else {
+    iconRendered = iconRender;
+  }
 
-	if (url) {
-		return (
-			<Link to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined} id={id} className={btnStyles} role={role} aria-label={ariaLabel} data-disabled={disabled} aria-controls={ariaControls} aria-expanded={ariaExpanded} data-bs-toggle={dataBsToggle} data-bs-target={ariaControls ? `#${ariaControls}` : undefined} aria-disabled={disabled ? true : undefined} onClick={onClick}>
-				{iconLeft ? iconRendered : ''}
-				<span>{children}</span>
-				{iconRight ? iconRendered : ''}
-				{(!iconLeft && !iconRight && icon) ? iconRendered : ''}
-			</Link>
-		)
-	}
-		return (
-			// eslint-disable-next-line react/button-has-type
-			<button id={id} type={type || 'button'} aria-label={ariaLabel} className={btnStyles} aria-controls={ariaControls} aria-expanded={ariaExpanded} data-bs-toggle={dataBsToggle} data-bs-target={ariaControls ? `#${ariaControls}` : undefined} aria-disabled={disabled ? true : undefined} title={title} onClick={onClick}>
-				{iconLeft ? iconRendered : ''}
-				<span>{children}</span>
-				{iconRight ? iconRendered : ''}
-				{(!iconLeft && !iconRight && icon) ? iconRendered : ''}
-			</button>
-		)
-	
+  if (url) {
+    return (
+      <Link
+        to={url}
+        target={blank ? "_blank" : undefined}
+        rel={blank ? "noreferrer" : undefined}
+        id={id}
+        className={btnStyles}
+        role={role}
+        aria-label={ariaLabel}
+        data-disabled={disabled}
+        aria-controls={ariaControls}
+        aria-expanded={ariaExpanded}
+        data-bs-toggle={dataBsToggle}
+        data-bs-target={ariaControls ? `#${ariaControls}` : undefined}
+        aria-disabled={disabled ? true : undefined}
+        onClick={onClick}
+      >
+        {iconLeft ? iconRendered : ""}
+        <span>{children}</span>
+        {iconRight ? iconRendered : ""}
+        {!iconLeft && !iconRight && icon ? iconRendered : ""}
+      </Link>
+    );
+  }
+  return (
+    // eslint-disable-next-line react/button-has-type
+    <button
+      id={id}
+      type={type || "button"}
+      aria-label={ariaLabel}
+      className={btnStyles}
+      aria-controls={ariaControls}
+      aria-expanded={ariaExpanded}
+      data-bs-toggle={dataBsToggle}
+      data-bs-target={ariaControls ? `#${ariaControls}` : undefined}
+      aria-disabled={disabled ? true : undefined}
+      title={title}
+      onClick={onClick}
+    >
+      {iconLeft ? iconRendered : ""}
+      <span>{children}</span>
+      {iconRight ? iconRendered : ""}
+      {!iconLeft && !iconRight && icon ? iconRendered : ""}
+    </button>
+  );
 }
 
-export default Button
+export default Button;

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -5,7 +5,7 @@ import "./button.scss";
 
 function Button({
   url,
-  type,
+  submit = false,
   size,
   id,
   label, // if data is yaml
@@ -78,10 +78,9 @@ function Button({
     );
   }
   return (
-    // eslint-disable-next-line react/button-has-type
     <button
       id={id}
-      type={type || "button"}
+      type={submit ? "submit" : "button"}
       aria-label={ariaLabel}
       className={btnStyles}
       aria-controls={ariaControls}

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -1,157 +1,222 @@
-import * as React from "react"
-import ReactMarkdown from "react-markdown"
-import ImageResponsive from "../image-responsive/image-responsive"
-import SimpleCta from "../simple-cta/simple-cta"
-import Chip from "../chip/chip"
-import Tag from "../tag/tag"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import Button from "../button/button"
-import ShareButton from "../share-button/share-button"
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import ImageResponsive from "../image-responsive/image-responsive";
+import SimpleCta from "../simple-cta/simple-cta";
+import Chip from "../chip/chip";
+import Tag from "../tag/tag";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import Button from "../button/button";
+import ShareButton from "../share-button/share-button";
 
-import "./card.scss"
+import "./card.scss";
 
 function Card({
-    cardEvent,
-    title,
-    titleSmall,
-    titleBig,
-    headingLevel,
-    url,
-    blank,
-    text,
-    textSerif,
-    tag,
-    share,
-    img,
-    imgRounded,
-    noShadow,
-    alt,
-    imgRatio,
-    iconOverlay,
-    dateOverlay,
-    chips,
-    tags,
-    externalLink,
-    moreInfo,
-    dateInfo,
-    imgPlaceholder,
-    iconImg,
-    iconImgAlt,
-    fullHeight,
-    rounded,
-    buttonBottom
-  }) {
-  const styles = 'di-card d-md-flex flex-md-column w-100'
-    + `${fullHeight ? ' fullheight' : ''}`
-    + `${rounded ? ' rounded' : ''}`
-    + `${titleSmall ? ' title-small' : ''}`
-    + `${titleBig ? ' title-big' : ''}`
-    + `${noShadow ? ' shadow-none' : ''}`
-    + `${textSerif ? ' text-serif' : ''}`
-    + `${buttonBottom ? ' has-button' : ''}`
+  cardEvent,
+  title,
+  titleSmall,
+  titleBig,
+  headingLevel,
+  url,
+  blank,
+  text,
+  textSerif,
+  tag,
+  share,
+  img,
+  imgRounded,
+  noShadow,
+  alt,
+  imgRatio,
+  iconOverlay,
+  dateOverlay,
+  chips,
+  tags,
+  externalLink,
+  moreInfo,
+  dateInfo,
+  imgPlaceholder,
+  iconImg,
+  iconImgAlt,
+  fullHeight,
+  rounded,
+  buttonBottom,
+}) {
+  const styles =
+    "di-card d-md-flex flex-md-column w-100" +
+    `${fullHeight ? " fullheight" : ""}` +
+    `${rounded ? " rounded" : ""}` +
+    `${titleSmall ? " title-small" : ""}` +
+    `${titleBig ? " title-big" : ""}` +
+    `${noShadow ? " shadow-none" : ""}` +
+    `${textSerif ? " text-serif" : ""}` +
+    `${buttonBottom ? " has-button" : ""}`;
 
-  const imgStyle = 'img-wrapper ratio'
-    + `${imgRatio ? ` ratio-${  imgRatio}` : ''}`
-    + `${imgPlaceholder ? ' img-placeholder' : ''}`
-    + `${iconImg ? ' icon-img' : ''}`
-    + `${cardEvent ? ' mb-4 negative-margin' : ''}`
-    + `${imgRounded ? ' rounded' : ''}`
+  const imgStyle =
+    "img-wrapper ratio" +
+    `${imgRatio ? ` ratio-${imgRatio}` : ""}` +
+    `${imgPlaceholder ? " img-placeholder" : ""}` +
+    `${iconImg ? " icon-img" : ""}` +
+    `${cardEvent ? " mb-4 negative-margin" : ""}` +
+    `${imgRounded ? " rounded" : ""}`;
 
-  const styleBody = 'di-card-body bg-white p-4 d-md-flex flex-md-column justify-content-between'
-    + `${rounded ? ' rounded' : ''}`
+  const styleBody =
+    "di-card-body bg-white p-4 d-md-flex flex-md-column justify-content-between" +
+    `${rounded ? " rounded" : ""}`;
 
   // heading level
-  let HLevel
+  let HLevel;
   if (headingLevel) {
     HLevel = `h${headingLevel}`;
   } else {
-    HLevel = `h3`
+    HLevel = `h3`;
   }
   if (cardEvent) {
     return (
       <div className={styles}>
         <div className={styleBody}>
           <div className="text-zone">
-            {HLevel && <HLevel><Link to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined}>{title}{(externalLink && !externalLink.url) && <SimpleCta {...externalLink} />}</Link></HLevel>}
-            {dateInfo && <span className="date-info font-monospace mb-3">{dateInfo}</span>}
+            {HLevel && (
+              <HLevel>
+                <Link
+                  to={url}
+                  target={blank ? "_blank" : undefined}
+                  rel={blank ? "noreferrer" : undefined}
+                >
+                  {title}
+                  {externalLink && !externalLink.url && (
+                    <SimpleCta {...externalLink} />
+                  )}
+                </Link>
+              </HLevel>
+            )}
+            {dateInfo && (
+              <span className="date-info font-monospace mb-3">{dateInfo}</span>
+            )}
             {text && <ReactMarkdown>{text}</ReactMarkdown>}
-            {(externalLink && externalLink.url) && <SimpleCta {...externalLink} />}
-            {moreInfo && <span className="more-info font-monospace">{moreInfo}</span>}
+            {externalLink && externalLink.url && (
+              <SimpleCta {...externalLink} />
+            )}
+            {moreInfo && (
+              <span className="more-info font-monospace">{moreInfo}</span>
+            )}
           </div>
           <div className="di-card-footer">
             <div className={imgStyle}>
-              {img && !imgPlaceholder && <ImageResponsive src={img} alt={alt} />}
+              {img && !imgPlaceholder && (
+                <ImageResponsive src={img} alt={alt} />
+              )}
               {iconImg && <ImageResponsive src={iconImg} alt={iconImgAlt} />}
-              {dateOverlay && <div className="date-overlay d-flex flex-column justify-content-center">
-                <span className="day font-monospace">{dateOverlay.day}</span>
-                <span className="month">{dateOverlay.month}</span>
-                <span className="month">{dateOverlay.year}</span>
-              </div>}
-              {iconOverlay && <div className="icon-overlay d-flex flex-column justify-content-center align-items-center">
-                <Icon {...iconOverlay} />
-              </div>}
+              {dateOverlay && (
+                <div className="date-overlay d-flex flex-column justify-content-center">
+                  <span className="day font-monospace">{dateOverlay.day}</span>
+                  <span className="month">{dateOverlay.month}</span>
+                  <span className="month">{dateOverlay.year}</span>
+                </div>
+              )}
+              {iconOverlay && (
+                <div className="icon-overlay d-flex flex-column justify-content-center align-items-center">
+                  <Icon {...iconOverlay} />
+                </div>
+              )}
             </div>
             <div className="di-card-footer-content d-flex justify-content-between align-items-end">
-              {tags && <div className="chip-container">
-                {tags.map((t, index) => (
-                    <Chip key={`chip-${  index}`} label={t} size="sm" />
+              {tags && (
+                <div className="chip-container">
+                  {tags.map((t, index) => (
+                    <Chip key={`chip-${index}`} label={t} size="sm" />
                   ))}
-              </div>}
-              {tag && <div className="tag-container">
-                <Tag {...tag} />
-              </div>}
-              { }
+                </div>
+              )}
+              {tag && (
+                <div className="tag-container">
+                  <Tag {...tag} />
+                </div>
+              )}
+              {}
               {url && <ShareButton url={url} title={title} small />}
             </div>
           </div>
         </div>
       </div>
-    )
+    );
   }
-    return (
-      <div className={styles}>
-        {(img || imgPlaceholder || iconImg) && <div className={imgStyle}>
+  return (
+    <div className={styles}>
+      {(img || imgPlaceholder || iconImg) && (
+        <div className={imgStyle}>
           {img && !imgPlaceholder && <ImageResponsive src={img} alt={alt} />}
           {iconImg && <ImageResponsive src={iconImg} alt={iconImgAlt} />}
-          {dateOverlay && <div className="date-overlay d-flex flex-column justify-content-center">
-            <span className="day font-monospace">{dateOverlay.day}</span>
-            <span className="month">{dateOverlay.month}</span>
-          </div>}
-          {iconOverlay && <div className="icon-overlay d-flex flex-column justify-content-center align-items-center">
-            <Icon {...iconOverlay} />
-          </div>}
-        </div>}
-        <div className={styleBody}>
-          <div className="text-zone">
-            {HLevel && <HLevel><Link to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined}>{title}{(externalLink && !externalLink.url) && <SimpleCta {...externalLink} />}</Link></HLevel>}
-            {dateInfo && <span className="date-info font-monospace mb-3">{dateInfo}</span>}
-            {text && <ReactMarkdown>{text}</ReactMarkdown>}
-            {(externalLink && externalLink.url) && <SimpleCta {...externalLink} />}
-            {moreInfo && <span className="more-info font-monospace">{moreInfo}</span>}
-            {buttonBottom &&
-              <div className="button-wrapper mt-4">
-                <Button {...buttonBottom} />
-              </div>
-            }
-          </div>
-          {(tag || tags || share || chips) && <div className="di-card-footer">
+          {dateOverlay && (
+            <div className="date-overlay d-flex flex-column justify-content-center">
+              <span className="day font-monospace">{dateOverlay.day}</span>
+              <span className="month">{dateOverlay.month}</span>
+            </div>
+          )}
+          {iconOverlay && (
+            <div className="icon-overlay d-flex flex-column justify-content-center align-items-center">
+              <Icon {...iconOverlay} />
+            </div>
+          )}
+        </div>
+      )}
+      <div className={styleBody}>
+        <div className="text-zone">
+          {HLevel && (
+            <HLevel>
+              <Link
+                to={url}
+                target={blank ? "_blank" : undefined}
+                rel={blank ? "noreferrer" : undefined}
+              >
+                {title}
+                {externalLink && !externalLink.url && (
+                  <SimpleCta {...externalLink} />
+                )}
+              </Link>
+            </HLevel>
+          )}
+          {dateInfo && (
+            <span className="date-info font-monospace mb-3">{dateInfo}</span>
+          )}
+          {text && <ReactMarkdown>{text}</ReactMarkdown>}
+          {externalLink && externalLink.url && <SimpleCta {...externalLink} />}
+          {moreInfo && (
+            <span className="more-info font-monospace">{moreInfo}</span>
+          )}
+          {buttonBottom && (
+            <div className="button-wrapper mt-4">
+              <Button {...buttonBottom} />
+            </div>
+          )}
+        </div>
+        {(tag || tags || share || chips) && (
+          <div className="di-card-footer">
             <div className="di-card-footer-content d-flex justify-content-between align-items-end">
-              {tags && <div className="chip-container">
-                {tags.map((t, index) => (
-                    <Chip key={`chip-${  index}`} label={t} size="sm" color="secondary" />
+              {tags && (
+                <div className="chip-container">
+                  {tags.map((t, index) => (
+                    <Chip
+                      key={`chip-${index}`}
+                      label={t}
+                      size="sm"
+                      color="secondary"
+                    />
                   ))}
-              </div>}
-              {tag && <div className="tag-container">
-                <Tag {...tag} />
-              </div>}
+                </div>
+              )}
+              {tag && (
+                <div className="tag-container">
+                  <Tag {...tag} />
+                </div>
+              )}
               {url && <ShareButton url={url} title={title} small />}
             </div>
-          </div>}
-        </div>
+          </div>
+        )}
       </div>
-    )
-
+    </div>
+  );
 }
 
-export default Card
+export default Card;

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -3,29 +3,23 @@ Create a checkbox functional component.
 Toggle the text of a paragraph with the checkbox using the 'useState' hook.
 */
 
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
 function Checkbox(props) {
-    const {
-        id,
-        label,
-        checked,
-        customStyle,
-        handleChange,
-    } = props;
-    const defaultChecked = checked || false;
-    const [isChecked, setIsChecked] = useState(defaultChecked);
-    const onClickEvent = (e) => {
-        e.preventDefault();
-        setIsChecked(!isChecked)
-        handleChange(!isChecked)
-    }
-    return (
-        <div className={`form-check ${  customStyle}`} onClick={onClickEvent}>
-            <input id={id} type="checkbox" checked={isChecked} onChange={()=>{}}/>
-            <label htmlFor={id}>{label}</label>
-        </div>
-    );
+  const { id, label, checked, customStyle, handleChange } = props;
+  const defaultChecked = checked || false;
+  const [isChecked, setIsChecked] = useState(defaultChecked);
+  const onClickEvent = (e) => {
+    e.preventDefault();
+    setIsChecked(!isChecked);
+    handleChange(!isChecked);
+  };
+  return (
+    <div className={`form-check ${customStyle}`} onClick={onClickEvent}>
+      <input id={id} type="checkbox" checked={isChecked} onChange={() => {}} />
+      <label htmlFor={id}>{label}</label>
+    </div>
+  );
 }
 
 export default Checkbox;

--- a/src/components/chip/chip.js
+++ b/src/components/chip/chip.js
@@ -1,26 +1,21 @@
-import * as React from "react"
-import kebabCase from "lodash/kebabCase"
+import * as React from "react";
+import kebabCase from "lodash/kebabCase";
 
-import './chip.scss'
-import Link from "../link/link"
+import "./chip.scss";
+import Link from "../link/link";
 
-function Chip({
-		size,
-		color,
-		path = "argomenti",
-		label,
-		children,
-	}) {
-	const styles = 'chip chip-simple'
-		+ `${size ? ` chip-${  size}` : ''}`
-		+ `${color ? ` chip-${  color}` : ''}`
+function Chip({ size, color, path = "argomenti", label, children }) {
+  const styles =
+    "chip chip-simple" +
+    `${size ? ` chip-${size}` : ""}` +
+    `${color ? ` chip-${color}` : ""}`;
 
-	return (
-		<Link to={`/${path}/${kebabCase(label)}/`} className={styles}>
-			<span className="chip-label">{label}</span>
-			{children}
-		</Link>
-	)
+  return (
+    <Link to={`/${path}/${kebabCase(label)}/`} className={styles}>
+      <span className="chip-label">{label}</span>
+      {children}
+    </Link>
+  );
 }
 
-export default Chip
+export default Chip;

--- a/src/components/component-view/component-view.js
+++ b/src/components/component-view/component-view.js
@@ -1,19 +1,20 @@
-import React, { useState, useEffect } from "react"
-import uniqueId from "lodash/uniqueId"
+import classNames from "classnames";
+import React, { useState, useEffect } from "react";
+import uniqueId from "lodash/uniqueId";
 
-import { a11yDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import loadable from "@loadable/component"
-import { Notification } from 'bootstrap-italia'
-import Button from "../button/button"
-import Checkbox from "../checkbox/checkbox"
-import Icon from "../icon/icon"
+import { a11yDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import loadable from "@loadable/component";
+import { Notification } from "bootstrap-italia";
+import Button from "../button/button";
+import Checkbox from "../checkbox/checkbox";
+import Icon from "../icon/icon";
 
-import "./component-view.scss"
-import viewerData from "../../data/component-viewer.yaml"
+import "./component-view.scss";
+import viewerData from "../../data/component-viewer.yaml";
 
-const slugify = require('slugify')
+const slugify = require("slugify");
 
-const SyntaxHighlighter = loadable(() => import('./syntax-highlighter'))
+const SyntaxHighlighter = loadable(() => import("./syntax-highlighter"));
 
 function ComponentView({
   variantName,
@@ -28,131 +29,146 @@ function ComponentView({
   accordionSrCopyLabel,
   componentViewerData,
 }) {
-
   let contentTrimmed = content?.trim();
 
-  if (componentViewerData?.variants) { // it is not a Componenti page, but a Fondamenti with one or more viewers...
-    contentTrimmed = componentViewerData
-      .variants
-      .filter(item => item.name === variantName)[0]
-      ?.content
-      ?.trim()
+  if (componentViewerData?.variants) {
+    // it is not a Componenti page, but a Fondamenti with one or more viewers...
+    contentTrimmed = componentViewerData.variants
+      .filter((item) => item.name === variantName)[0]
+      ?.content?.trim();
   }
 
-  const { viewer, accordionLabel, accordionSrLabel } = viewerData
+  const { viewer, accordionLabel, accordionSrLabel } = viewerData;
 
   const ICON_EXTERNAL = {
     icon: "sprites.svg#it-external-link",
     size: "sm",
     color: "primary",
     addonClasses: "align-middle me-4 mb-1",
-    ariaLabel: " (Link esterno)"
-  }
+    ariaLabel: " (Link esterno)",
+  };
 
   const ICON_COPY_CODE = {
     icon: "sprites.svg#it-copy",
     size: "sm",
     color: "primary",
     addonClasses: "align-middle me-4 mb-1 mt-1",
-    ariaLabel: " Copia il codice negli appunti"
-  }
+    ariaLabel: " Copia il codice negli appunti",
+  };
 
   const ICON_FULLSCREEN = {
     icon: "sprites.svg#it-fullscreen",
     size: "sm",
     color: "primary",
     addonClasses: "align-middle me-4 mb-1",
-    ariaLabel: " Mostra in una finestra dedicata"
-  }
+    ariaLabel: " Mostra in una finestra dedicata",
+  };
 
   const ICON_SUCCESS = {
     icon: "sprites.svg#it-check-circle",
-  }
+  };
 
   const initAutoHeight = () => {
-    const iframe = document.getElementById(`${idPrefix}-iframe`)
-    if (!iframe) return
-    const exampleContainer = iframe.contentWindow.document.getElementsByClassName("bd-example")[0]
-    if (!exampleContainer) return
+    const iframe = document.getElementById(`${idPrefix}-iframe`);
+    if (!iframe) return;
+    const exampleContainer =
+      iframe.contentWindow.document.getElementsByClassName("bd-example")[0];
+    if (!exampleContainer) return;
     if (viewerHeight === 0 || !viewerHeight) {
       // auto height
       if (!minHeight) {
-        iframe.classList.add("min-default-height")
+        iframe.classList.add("min-default-height");
       } else {
-        iframe.style.minHeight = `${minHeight}px`
+        iframe.style.minHeight = `${minHeight}px`;
       }
-      iframe.height = exampleContainer.clientHeight + 50
+      iframe.height = exampleContainer.clientHeight + 50;
       exampleContainer.addEventListener("click", () => {
         setTimeout(() => {
-          iframe.height = exampleContainer.clientHeight + 50
-        }, 50)
-      })
-      const tabs = document.querySelector('.nav-tabs')
-      if (!tabs) return
+          iframe.height = exampleContainer.clientHeight + 50;
+        }, 50);
+      });
+      const tabs = document.querySelector(".nav-tabs");
+      if (!tabs) return;
       tabs.addEventListener("click", () => {
         setTimeout(() => {
-          iframe.height = exampleContainer.clientHeight + 50
-        }, 50)
-      })
+          iframe.height = exampleContainer.clientHeight + 50;
+        }, 50);
+      });
     } else if (viewerHeight > 0) {
       // fixed width
-      iframe.height = viewerHeight + 50
-      exampleContainer.classList.add("h-100")
+      iframe.height = viewerHeight + 50;
+      exampleContainer.classList.add("h-100");
     }
-  }
+  };
 
   useEffect(() => {
-    initAutoHeight()
-    const iframe = document.getElementById(`${idPrefix}-iframe`)
-    if (!iframe) return
-    iframe.addEventListener("load", initAutoHeight)
-    iframe.addEventListener("transitionend", initAutoHeight)
-  })
+    initAutoHeight();
+    const iframe = document.getElementById(`${idPrefix}-iframe`);
+    if (!iframe) return;
+    iframe.addEventListener("load", initAutoHeight);
+    iframe.addEventListener("transitionend", initAutoHeight);
+  });
 
   const theme = a11yDark;
 
   const copyToClipboard = (e, code) => {
-    e.preventDefault()
-    navigator.clipboard.writeText(code)
-    const notification = new Notification(document.getElementById(`${idPrefix}-copyToast`), {
-      timeout: 3000
-    })
-    notification.show()
-  }
+    e.preventDefault();
+    navigator.clipboard.writeText(code);
+    const notification = new Notification(
+      document.getElementById(`${idPrefix}-copyToast`),
+      {
+        timeout: 3000,
+      },
+    );
+    notification.show();
+  };
 
-  const uuid = `${idPrefix}-component-view-${uniqueId('id_')}`
-  const accId = `${uuid}-accordion`
-  const headId = `${uuid}-heading`
-  const collId = `${uuid}-collapse`
-  const [wrappedCode, setWrappedCode] = useState(false)
+  const uuid = `${idPrefix}-component-view-${uniqueId("id_")}`;
+  const accId = `${uuid}-accordion`;
+  const headId = `${uuid}-heading`;
+  const collId = `${uuid}-collapse`;
+  const [wrappedCode, setWrappedCode] = useState(false);
 
-  const [previewWidth, setPreviewWidth] = useState(" viewer-desktop")
+  const [previewWidth, setPreviewWidth] = useState(" viewer-desktop");
   const changeResolution = (e) => {
-    e.preventDefault()
-    const res = e.target.textContent // mobile, tablet, desktop
-    setPreviewWidth(` viewer-${res}`)
-  }
+    e.preventDefault();
+    const res = e.target.textContent; // mobile, tablet, desktop
+    setPreviewWidth(` viewer-${res}`);
+  };
 
-  let responsiveButtonsItems
+  let responsiveButtonsItems;
   if (viewer) {
-    responsiveButtonsItems = (viewer.responsiveButtons).map((item, index) => (
-        <Button onClick={(e) => changeResolution(e)} key={`rb${  index}`} {...item} />
-      ))
+    responsiveButtonsItems = viewer.responsiveButtons.map((item, index) => (
+      <Button
+        onClick={(e) => changeResolution(e)}
+        key={`rb${index}`}
+        {...item}
+      />
+    ));
   }
 
-  const componentStyles = "border-bottom p-xl-3 d-flex flex-column align-items-center"
-    + `${responsiveButtonsItems ? ' pb-4' : ''}`
+  const componentStyles = classNames(
+    "border-bottom p-xl-3 d-flex flex-column align-items-center",
+    { "pb-4": responsiveButtonsItems },
+  );
 
-  const accordionStyle = "accordion-collapse collapse"
-    + `${accordionOpen ? ' show' : ' hide'}`
-  const accordionButtonStyle = "accordion-button border-top-0 collapsed"
-    + `${accordionOpen ? ' collapsed' : ''}`
+  const accordionStyle = classNames("accordion-collapse collapse", {
+    show: accordionOpen,
+    hide: !accordionOpen,
+  });
 
-  const BSIExampleUrl = `/examples/${source}/${slugify(variantName).toLowerCase()}.html`
+  const accordionButtonStyle = classNames(
+    "accordion-button border-top-0 collapsed",
+    { collapsed: accordionOpen },
+  );
+
+  const BSIExampleUrl = `/examples/${source}/${slugify(
+    variantName,
+  ).toLowerCase()}.html`;
 
   return (
     <div id={uuid} className="pb-4 mb-5">
-      {contentTrimmed &&
+      {contentTrimmed && (
         <div className={componentStyles}>
           <span className="visually-hidden">Inizio componente:</span>
           <iframe
@@ -162,66 +178,120 @@ function ComponentView({
             className={`w-100 rounded border shadow-sm iframe-example ${previewWidth}`}
           />
           <span className="visually-hidden">Fine componente.</span>
-          {responsiveButtonsItems &&
+          {responsiveButtonsItems && (
             <div className="responsive-buttons d-none d-lg-block">
               <div className="d-flex align-items-center justify-content-center pb-2 pt-4 mt-2">
-                {viewer.label &&
-                  <span className="small pe-3 text-secondary fw-semibold">{viewer.label}</span>
-                }
+                {viewer.label && (
+                  <span className="small pe-3 text-secondary fw-semibold">
+                    {viewer.label}
+                  </span>
+                )}
                 {responsiveButtonsItems}
               </div>
             </div>
-          }
+          )}
         </div>
-      }
-      {(contentTrimmed && accordionShow) &&
+      )}
+      {contentTrimmed && accordionShow && (
         <div className="accordion accordion-left-icon" id={accId}>
           <div className="accordion-item">
-            <div className="d-flex justify-content-between align-items-center" id={headId}>
+            <div
+              className="d-flex justify-content-between align-items-center"
+              id={headId}
+            >
               <h2 id={`${idPrefix}-codeViewer`} className="accordion-header ">
-                <button className={accordionButtonStyle} type="button" data-bs-toggle="collapse" data-bs-target={`#${collId}`} aria-expanded={accordionOpen} aria-controls={collId}>
+                <button
+                  className={accordionButtonStyle}
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target={`#${collId}`}
+                  aria-expanded={accordionOpen}
+                  aria-controls={collId}
+                >
                   {accordionLabel}
                 </button>
               </h2>
               <div className="d-flex justify-content-between align-items-center">
-                {contentTrimmed &&
-                  <Button onClick={(e) => copyToClipboard(e, contentTrimmed)} aria-label={accordionSrCopyLabel} addonStyle="p-0 shadow-none">
+                {contentTrimmed && (
+                  <Button
+                    onClick={(e) => copyToClipboard(e, contentTrimmed)}
+                    aria-label={accordionSrCopyLabel}
+                    addonStyle="p-0 shadow-none"
+                  >
                     <Icon {...ICON_COPY_CODE} />
                   </Button>
-                }
-                <a href={BSIExampleUrl} target="_blank" rel="noreferrer" aria-label="Mostra il solo componente in una finestra dedicata">
+                )}
+                <a
+                  href={BSIExampleUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="Mostra il solo componente in una finestra dedicata"
+                >
                   <Icon {...ICON_FULLSCREEN} />
                 </a>
-                {accordionUrl &&
-                  <a href={accordionUrl} target="_blank" rel="noreferrer" aria-label={accordionSrLabel}>
+                {accordionUrl && (
+                  <a
+                    href={accordionUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={accordionSrLabel}
+                  >
                     <Icon {...ICON_EXTERNAL} />
                   </a>
-                }
+                )}
               </div>
             </div>
 
-            <div id={collId} className={accordionStyle} data-bs-parent={`#${  accId}`} role="region" aria-labelledby={headId}>
+            <div
+              id={collId}
+              className={accordionStyle}
+              data-bs-parent={`#${accId}`}
+              role="region"
+              aria-labelledby={headId}
+            >
               <div className="accordion-body p-0">
                 <div aria-hidden="true" className="d-flex flex-row-reverse">
-                  {contentTrimmed &&
-                    <Checkbox id={`${idPrefix}-wrap`} label='Mostra codice a capo' customStyle="me-4" checked={wrappedCode} handleChange={(val) => setWrappedCode(val)} />
-                  }
+                  {contentTrimmed && (
+                    <Checkbox
+                      id={`${idPrefix}-wrap`}
+                      label="Mostra codice a capo"
+                      customStyle="me-4"
+                      checked={wrappedCode}
+                      handleChange={(val) => setWrappedCode(val)}
+                    />
+                  )}
                 </div>
-                {content &&
-                  <SyntaxHighlighter language="markup" style={theme} showLineNumbers wrapLines={wrappedCode} lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }}>
+                {content && (
+                  <SyntaxHighlighter
+                    language="markup"
+                    style={theme}
+                    showLineNumbers
+                    wrapLines={wrappedCode}
+                    lineProps={{
+                      style: { wordBreak: "break-all", whiteSpace: "pre-wrap" },
+                    }}
+                  >
                     {content}
                   </SyntaxHighlighter>
-                }
+                )}
               </div>
             </div>
-            <div className="notification with-icon right-fix success dismissable fade" role="alert" aria-labelledby={`${idPrefix}-not1d-title`} id={`${idPrefix}-copyToast`}>
-              <span id={`${idPrefix}-not1d-title`} className="h5 "><Icon {...ICON_SUCCESS} />Codice copiato negli appunti</span>
+            <div
+              className="notification with-icon right-fix success dismissable fade"
+              role="alert"
+              aria-labelledby={`${idPrefix}-not1d-title`}
+              id={`${idPrefix}-copyToast`}
+            >
+              <span id={`${idPrefix}-not1d-title`} className="h5 ">
+                <Icon {...ICON_SUCCESS} />
+                Codice copiato negli appunti
+              </span>
             </div>
           </div>
         </div>
-      }
+      )}
     </div>
-  )
+  );
 }
 
-export default ComponentView
+export default ComponentView;

--- a/src/components/component-view/syntax-highlighter.js
+++ b/src/components/component-view/syntax-highlighter.js
@@ -1,4 +1,4 @@
 // import SyntaxHighlighter from 'react-syntax-highlighter';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 
 export default SyntaxHighlighter;

--- a/src/components/content-collapse/contentCollapse.js
+++ b/src/components/content-collapse/contentCollapse.js
@@ -1,64 +1,68 @@
-import React, { useRef, useEffect, useState } from "react"
-import ReactMarkdown from "react-markdown"
+import React, { useRef, useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
 
-import { Collapse } from "bootstrap-italia"
+import { Collapse } from "bootstrap-italia";
 
-import Icon from "../icon/icon"
+import Icon from "../icon/icon";
 
-import "./content-collapse.scss"
+import "./content-collapse.scss";
 
-function ContentCollapse({
-  label,
-  labelClose,
-  children,
-}) {
-
-  const icon = ({
+function ContentCollapse({ label, labelClose, children }) {
+  const icon = {
     icon: "sprites.svg#it-expand",
     size: "sm",
-    align : "middle",
-    color :"primary",
+    align: "middle",
+    color: "primary",
     hidden: true,
-    addonClasses: "ms-2"
-  })
+    addonClasses: "ms-2",
+  };
 
-  const collRef = useRef(null)
-  const collObjRef = useRef(null)
+  const collRef = useRef(null);
+  const collObjRef = useRef(null);
   // const id = 'content-collapse-' + new Date().getTime()
 
-  const [id, setId] = useState('content-collapse-')
+  const [id, setId] = useState("content-collapse-");
 
   const toggleAria = (element) => {
-    const ariaAttr = element.getAttribute('aria-expanded')
-    let newVal = 'true'
-    if (ariaAttr === 'true') {
-      newVal = 'false'
+    const ariaAttr = element.getAttribute("aria-expanded");
+    let newVal = "true";
+    if (ariaAttr === "true") {
+      newVal = "false";
     }
-    element.setAttribute('aria-expanded', newVal)
-  }
+    element.setAttribute("aria-expanded", newVal);
+  };
   const collapseToggle = (evt) => {
-    evt.preventDefault()
+    evt.preventDefault();
     if (collObjRef.current) {
-      collObjRef.current.toggle()
-      toggleAria(evt.currentTarget)
+      collObjRef.current.toggle();
+      toggleAria(evt.currentTarget);
     }
-  }
+  };
 
   useEffect(() => {
-    collObjRef.current = new Collapse(collRef.current, { toggle: false })
-    setId(`content-collapse-${  new Date().getTime()}`)
-  }, [])
+    collObjRef.current = new Collapse(collRef.current, { toggle: false });
+    setId(`content-collapse-${new Date().getTime()}`);
+  }, []);
 
-  return <div className="content-collapse">
-    <a href="#" role="button" onClick={collapseToggle} className="read-more mt-3 d-inline-flex align-items-center text-decoration-none" /* data-bs-toggle="collapse" data-bs-target={'#'+id+'ReadMore'} */ aria-expanded="false" aria-controls={id}>
-      <span className="more-text">{label}</span>
-      <span className="less-text">{labelClose}</span>
-      <Icon {...icon}/>
-    </a>
-    <div ref={collRef} className="collapse" id={id}>
-      <ReactMarkdown className="mt-4">{children}</ReactMarkdown>
+  return (
+    <div className="content-collapse">
+      <a
+        href="#"
+        role="button"
+        onClick={collapseToggle}
+        className="read-more mt-3 d-inline-flex align-items-center text-decoration-none"
+        /* data-bs-toggle="collapse" data-bs-target={'#'+id+'ReadMore'} */ aria-expanded="false"
+        aria-controls={id}
+      >
+        <span className="more-text">{label}</span>
+        <span className="less-text">{labelClose}</span>
+        <Icon {...icon} />
+      </a>
+      <div ref={collRef} className="collapse" id={id}>
+        <ReactMarkdown className="mt-4">{children}</ReactMarkdown>
+      </div>
     </div>
-  </div>
+  );
 }
 
-export default ContentCollapse
+export default ContentCollapse;

--- a/src/components/content-select/components/content-select-item/content-select-item.js
+++ b/src/components/content-select/components/content-select-item/content-select-item.js
@@ -1,11 +1,7 @@
-import React from "react"
+import React from "react";
 
 function ContentSelectItem({ children }) {
-  return (
-    <div className="content-select-item">
-      { children }
-    </div>
-  )
+  return <div className="content-select-item">{children}</div>;
 }
 
-export default ContentSelectItem
+export default ContentSelectItem;

--- a/src/components/content-select/content-select.js
+++ b/src/components/content-select/content-select.js
@@ -1,79 +1,86 @@
-import React, { useState } from "react"
+import React, { useState } from "react";
 
-import ContentSelectItem from "./components/content-select-item/content-select-item"
-import Icon from "../icon/icon"
+import ContentSelectItem from "./components/content-select-item/content-select-item";
+import Icon from "../icon/icon";
 
-import './content-select.scss'
+import "./content-select.scss";
 
-const VARIANT_PREFIX = 'variant-'
+const VARIANT_PREFIX = "variant-";
 
-function ContentSelect({
-  id,
-  title,
-  textInfo,
-  children,
-  selectedIdx,
-  label
-}) {
-
+function ContentSelect({ id, title, textInfo, children, selectedIdx, label }) {
   // FIXME: Using Number.isNaN() breaks the component viewer in the *static*
   // build, while still working with the dev server. No clue why.
   // https://github.com/italia/designers.italia.it/pull/842#issuecomment-1691861173
-  //
-  // eslint-disable-next-line no-restricted-globals
-  const [itemSelected, setItemSelected] = useState(!isNaN(selectedIdx) ? VARIANT_PREFIX + selectedIdx : VARIANT_PREFIX + 0)
+  const [itemSelected, setItemSelected] = useState(
+    // eslint-disable-next-line no-restricted-globals
+    !isNaN(selectedIdx) ? VARIANT_PREFIX + selectedIdx : VARIANT_PREFIX + 0,
+  );
 
   const changeValue = (evt) => {
-    setItemSelected(evt.currentTarget.value)
-  }
+    setItemSelected(evt.currentTarget.value);
+  };
 
-  const variants = []
+  const variants = [];
   React.Children.forEach(children, (child, idx) => {
     if (child.type === ContentSelectItem) {
       variants.push({
         name: child.props.name,
         value: VARIANT_PREFIX + idx,
-        component: child
-      })
+        component: child,
+      });
     } else {
-      throw new Error('ContentSelect accepts only ContentSelectItem as its children')
+      throw new Error(
+        "ContentSelect accepts only ContentSelectItem as its children",
+      );
     }
-  })
+  });
 
-  const selectedChild = variants.find((v) => itemSelected === v.value)
+  const selectedChild = variants.find((v) => itemSelected === v.value);
 
   const ICON_INFO = {
     icon: "sprites.svg#it-info-circle",
     size: "sm",
     color: "muted",
     addonClasses: "align-middle me-2 mb-1",
-    ariaLabel: " Info"
-  }
+    ariaLabel: " Info",
+  };
 
   return (
     <section className="container-xxl" aria-labelledby={id}>
       <div className="row">
         <div className="col-9 mb-5">
-          <h2 id={id} className="px-3 px-md-0">{title}</h2>
+          <h2 id={id} className="px-3 px-md-0">
+            {title}
+          </h2>
         </div>
         <div className="col-12 col-md-6 col-lg-5 mb-4">
           <div className="select-wrapper px-3 px-md-0">
-            <label htmlFor={`${id  }-select`}>{label}</label>
-            <select value={itemSelected} onChange={changeValue} autoComplete="off" id={`${id  }-select`}>
-              {variants.map((v, idx) => <option key={`opt-${  idx}`} value={v.value}>{v.name}</option>)}
+            <label htmlFor={`${id}-select`}>{label}</label>
+            <select
+              value={itemSelected}
+              onChange={changeValue}
+              autoComplete="off"
+              id={`${id}-select`}
+            >
+              {variants.map((v, idx) => (
+                <option key={`opt-${idx}`} value={v.value}>
+                  {v.name}
+                </option>
+              ))}
             </select>
           </div>
         </div>
-        {textInfo && <div className="col-9">
-          <p className="small"><Icon {...ICON_INFO} /> {textInfo}</p>
-        </div>
-        }
-        <div className="col-12">
-          {selectedChild && selectedChild.component}
-        </div>
+        {textInfo && (
+          <div className="col-9">
+            <p className="small">
+              <Icon {...ICON_INFO} /> {textInfo}
+            </p>
+          </div>
+        )}
+        <div className="col-12">{selectedChild && selectedChild.component}</div>
       </div>
     </section>
-  )
+  );
 }
 
-export default ContentSelect
+export default ContentSelect;

--- a/src/components/dropdown-menu/dropdown-menu.js
+++ b/src/components/dropdown-menu/dropdown-menu.js
@@ -1,14 +1,15 @@
-import * as React from "react"
+import * as React from "react";
 
-function DropdownMenu({
-	idMegamenu,
-	children
-}) {
-	return (
-		<div className="dropdown-menu shadow-lg" role="region" aria-labelledby={idMegamenu}>
-			{children}
-		</div>
-	)
+function DropdownMenu({ idMegamenu, children }) {
+  return (
+    <div
+      className="dropdown-menu shadow-lg"
+      role="region"
+      aria-labelledby={idMegamenu}
+    >
+      {children}
+    </div>
+  );
 }
 
-export default DropdownMenu
+export default DropdownMenu;

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1,46 +1,58 @@
-import * as React from "react"
-import Button from "../button/button"
-import List from "../list/list"
-import "./dropdown.scss"
-
+import * as React from "react";
+import Button from "../button/button";
+import List from "../list/list";
+import "./dropdown.scss";
 
 function Dropdown({
-	btnId,
-	dropUp,
-	dropEnd,
-	dropStart,
-	list,
-	children,
-	button,
-	customStyle,
-	shareUrl,
+  btnId,
+  dropUp,
+  dropEnd,
+  dropStart,
+  list,
+  children,
+  button,
+  customStyle,
+  shareUrl,
   shareTitle,
 }) {
+  const styles =
+    "dropdown" +
+    `${dropUp ? " dropup" : ""}` +
+    `${dropEnd ? " dropend" : ""}` +
+    `${dropStart ? " dropstart" : ""}` +
+    `${customStyle ? ` ${customStyle}` : ""}`;
 
-	const styles = "dropdown"
-		+ `${dropUp ? ' dropup' : ''}`
-		+ `${dropEnd ? ' dropend' : ''}`
-		+ `${dropStart ? ' dropstart' : ''}`
-		+ `${customStyle ? ` ${customStyle}` : ''}`
+  let btnComponents;
+  if (button) {
+    btnComponents = (
+      <Button
+        id={btnId}
+        ariaExpanded="false"
+        ariaHaspopup="true"
+        dataBsToggle="dropdown"
+        {...button}
+      />
+    );
+  }
 
-	let btnComponents
-	if (button) {
-		btnComponents = <Button
-			id={btnId}
-			ariaExpanded="false"
-			ariaHaspopup="true"
-			dataBsToggle="dropdown"
-			{...button} />
-	}
-
-	return (
-		<div className={styles}>
-			{btnComponents}
-			<div className="dropdown-menu" aria-labelledby={btnId}>
-				{list ? <List {...list} shareUrl={shareUrl} shareTitle={shareTitle} isMenu isDropdown /> : children}
-			</div>
-		</div>
-	)
+  return (
+    <div className={styles}>
+      {btnComponents}
+      <div className="dropdown-menu" aria-labelledby={btnId}>
+        {list ? (
+          <List
+            {...list}
+            shareUrl={shareUrl}
+            shareTitle={shareTitle}
+            isMenu
+            isDropdown
+          />
+        ) : (
+          children
+        )}
+      </div>
+    </div>
+  );
 }
 
-export default Dropdown
+export default Dropdown;

--- a/src/components/feedback/components/form-no/FormNo.js
+++ b/src/components/feedback/components/form-no/FormNo.js
@@ -1,35 +1,35 @@
-import React, { useCallback, useState, useRef } from "react"
-import ImageResponsive from "../../../image-responsive/image-responsive"
-import LabelTextArea from "../../../label-textarea/label-text-area"
-import Icon from "../../../icon/icon"
+import React, { useCallback, useState, useRef } from "react";
+import ImageResponsive from "../../../image-responsive/image-responsive";
+import LabelTextArea from "../../../label-textarea/label-text-area";
+import Icon from "../../../icon/icon";
 
-import FeedbackState from "../../state"
+import FeedbackState from "../../state";
 
-import './form-no.scss'
+import "./form-no.scss";
 
 const ICON_USER = {
   icon: "sprites.svg#it-user",
   size: "lg",
   color: "secondary",
   addonClasses: "align-middle me-3",
-  hidden: true
-}
+  hidden: true,
+};
 
 const ICON_HELP = {
   icon: "sprites.svg#it-help-circle",
   size: "lg",
   color: "secondary",
   addonClasses: "align-middle me-3",
-  hidden: true
-}
+  hidden: true,
+};
 
 const ICON_INFO = {
   icon: "sprites.svg#it-info-circle",
   size: "lg",
   color: "secondary",
   addonClasses: "align-middle me-3",
-  hidden: true
-}
+  hidden: true,
+};
 
 function FormNo({ onResult, state }) {
   const rootRef = useRef(null);
@@ -39,143 +39,270 @@ function FormNo({ onResult, state }) {
   const [details, setDetails] = useState(null);
 
   const handleClick = useCallback(() => {
-    onResult({who, from, details})
-  }, [who, from, details, onResult])
+    onResult({ who, from, details });
+  }, [who, from, details, onResult]);
 
-  return <div ref={rootRef}>
-    <form>
-      <ImageResponsive src="/images/kit-analitics.svg" alt="" />
-      <h2 className="mb-3" id="feedbackNoTitle">Grazie per la tua risposta!</h2>
+  return (
+    <div ref={rootRef}>
+      <form>
+        <ImageResponsive src="/images/kit-analitics.svg" alt="" />
+        <h2 className="mb-3" id="feedbackNoTitle">
+          Grazie per la tua risposta!
+        </h2>
 
-      <h3 className="mb-3">Aiutaci a migliorare dandoci qualche dettaglio in più.</h3>
-      <p>
-        Quanto segue è una raccolta di informazioni anonima, che ci aiuta a capire come
-        migliorare la tua esperienza sul sito senza trattare dati personali.
-        Se sei un developer puoi scoprire come funziona questo meccanismo nella <a href="https://github.com/italia/feedback.designers.italia.it" target="_blank" rel="noreferrer" aria-label="repository GitHub dedicata (si apre in una nuova finestra">repository GitHub dedicata</a>.
-      </p>
+        <h3 className="mb-3">
+          Aiutaci a migliorare dandoci qualche dettaglio in più.
+        </h3>
+        <p>
+          Quanto segue è una raccolta di informazioni anonima, che ci aiuta a
+          capire come migliorare la tua esperienza sul sito senza trattare dati
+          personali. Se sei un developer puoi scoprire come funziona questo
+          meccanismo nella{" "}
+          <a
+            href="https://github.com/italia/feedback.designers.italia.it"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="repository GitHub dedicata (si apre in una nuova finestra"
+          >
+            repository GitHub dedicata
+          </a>
+          .
+        </p>
 
-      <fieldset onChange={e => setWho(e.target.value)}>
-        <legend className="d-flex mb-3 px-0 align-items-center w-75">
-          <Icon {...ICON_USER} />
-          <span className="text-secondary">Sei:</span>
-        </legend>
-        <div className="px-3 px-lg-5 py-3 py-lg-5 rounded shadow-lg">
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt1" value="Designer" />
-            <label htmlFor="optsStep1Opt1">Designer</label>
+        <fieldset onChange={(e) => setWho(e.target.value)}>
+          <legend className="d-flex mb-3 px-0 align-items-center w-75">
+            <Icon {...ICON_USER} />
+            <span className="text-secondary">Sei:</span>
+          </legend>
+          <div className="px-3 px-lg-5 py-3 py-lg-5 rounded shadow-lg">
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt1"
+                value="Designer"
+              />
+              <label htmlFor="optsStep1Opt1">Designer</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt2"
+                value="Developer"
+              />
+              <label htmlFor="optsStep1Opt2">Developer</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt3"
+                value="Dirigente"
+              />
+              <label htmlFor="optsStep1Opt3">Dirigente</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt4"
+                value="Docente"
+              />
+              <label htmlFor="optsStep1Opt4">Docente</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt5"
+                value="Editor"
+              />
+              <label htmlFor="optsStep1Opt5">Editor</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt6"
+                value="Legale"
+              />
+              <label htmlFor="optsStep1Opt6">Legale</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt7"
+                value="Personale amministrativo"
+              />
+              <label htmlFor="optsStep1Opt7">Personale amministrativo</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt8"
+                value="Project manager"
+              />
+              <label htmlFor="optsStep1Opt8">Project manager</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt9"
+                value="Specialista comunicazione"
+              />
+              <label htmlFor="optsStep1Opt9">Specialista comunicazione</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt10"
+                value="Studente"
+              />
+              <label htmlFor="optsStep1Opt10">Studente</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep1"
+                type="radio"
+                id="optsStep1Opt11"
+                value="Qui per curiosità / interesse"
+              />
+              <label htmlFor="optsStep1Opt11">
+                Qui per curiosità / interesse
+              </label>
+            </div>
           </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt2" value="Developer" />
-            <label htmlFor="optsStep1Opt2">Developer</label>
+        </fieldset>
+
+        <fieldset onChange={(e) => setFrom(e.target.value)}>
+          <legend className="d-flex mb-3 px-0 pt-5 align-items-center w-75">
+            <Icon {...ICON_HELP} />
+            <span className="text-secondary">
+              Hai trovato questa pagina grazie a:
+            </span>
+          </legend>
+          <div className="px-3 px-lg-5 py-3 py-lg-5 rounded shadow-lg">
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep2"
+                type="radio"
+                id="optsStep2Opt1"
+                value="altro sito web"
+              />
+              <label htmlFor="optsStep2Opt1">Altro sito web</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep2"
+                type="radio"
+                id="optsStep2Opt2"
+                value="funzione Cerca del sito"
+              />
+              <label htmlFor="optsStep2Opt2">Funzione Cerca del sito</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep2"
+                type="radio"
+                id="optsStep2Opt3"
+                value="motore di ricerca"
+              />
+              <label htmlFor="optsStep2Opt3">Motore di ricerca</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep2"
+                type="radio"
+                id="optsStep2Opt4"
+                value="messaggio social"
+              />
+              <label htmlFor="optsStep2Opt4">Messaggio social</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep2"
+                type="radio"
+                id="optsStep2Opt5"
+                value="navigazione del sito"
+              />
+              <label htmlFor="optsStep2Opt5">Navigazione del sito</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep2"
+                type="radio"
+                id="optsStep2Opt6"
+                value="posta elettronica"
+              />
+              <label htmlFor="optsStep2Opt6">Posta elettronica</label>
+            </div>
+            <div className="form-check form-check-group">
+              <input
+                name="optsStep2"
+                type="radio"
+                id="optsStep2Opt7"
+                value="altro"
+              />
+              <label htmlFor="optsStep2Opt7">Altro</label>
+            </div>
           </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt3" value="Dirigente" />
-            <label htmlFor="optsStep1Opt3">Dirigente</label>
+        </fieldset>
+
+        <fieldset onChange={(e) => setDetails(e.target.value)}>
+          <legend className="d-flex pt-5 pb-4 px-0 align-items-center w-75">
+            <Icon {...ICON_INFO} />
+            <span className="text-secondary">
+              Come possiamo migliorare questa pagina?
+            </span>
+          </legend>
+          <div className="px-3 px-lg-5 pt-5 pb-1 rounded shadow-lg">
+            <div className="form-group">
+              <LabelTextArea
+                ariadescribedby="helperText"
+                id="feedbackText"
+                label="Risposta"
+                rows="3"
+                maxLength="200"
+              />
+              <small id="helperText" className="form-control form-text">
+                Hai a disposizione 200 caratteri. Per favore non inserire dati
+                personali in questo campo.
+              </small>
+            </div>
           </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt4" value="Docente" />
-            <label htmlFor="optsStep1Opt4">Docente</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt5" value="Editor" />
-            <label htmlFor="optsStep1Opt5">Editor</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt6" value="Legale" />
-            <label htmlFor="optsStep1Opt6">Legale</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt7" value="Personale amministrativo" />
-            <label htmlFor="optsStep1Opt7">Personale amministrativo</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt8" value="Project manager" />
-            <label htmlFor="optsStep1Opt8">Project manager</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt9" value="Specialista comunicazione" />
-            <label htmlFor="optsStep1Opt9">Specialista comunicazione</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt10" value="Studente" />
-            <label htmlFor="optsStep1Opt10">Studente</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep1" type="radio" id="optsStep1Opt11" value="Qui per curiosità / interesse" />
-            <label htmlFor="optsStep1Opt11">Qui per curiosità / interesse</label>
-          </div>
+        </fieldset>
+
+        <div className="mt-5">
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={
+              (!who && !from && !details) || state === FeedbackState.Loading
+            }
+            onClick={handleClick}
+          >
+            {state === FeedbackState.Loading ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  role="status"
+                  aria-hidden="true"
+                />
+                <span className="sr-only">Invio in corso...</span>
+              </>
+            ) : (
+              "Invia dettagli"
+            )}
+          </button>
         </div>
-      </fieldset>
-
-      <fieldset onChange={e => setFrom(e.target.value)}>
-        <legend className="d-flex mb-3 px-0 pt-5 align-items-center w-75">
-          <Icon {...ICON_HELP} />
-          <span className="text-secondary">Hai trovato questa pagina grazie a:</span>
-        </legend>
-        <div className="px-3 px-lg-5 py-3 py-lg-5 rounded shadow-lg">
-          <div className="form-check form-check-group">
-            <input name="optsStep2" type="radio" id="optsStep2Opt1" value="altro sito web" />
-            <label htmlFor="optsStep2Opt1">Altro sito web</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep2" type="radio" id="optsStep2Opt2" value="funzione Cerca del sito" />
-            <label htmlFor="optsStep2Opt2">Funzione Cerca del sito</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep2" type="radio" id="optsStep2Opt3" value="motore di ricerca" />
-            <label htmlFor="optsStep2Opt3">Motore di ricerca</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep2" type="radio" id="optsStep2Opt4" value="messaggio social" />
-            <label htmlFor="optsStep2Opt4">Messaggio social</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep2" type="radio" id="optsStep2Opt5" value="navigazione del sito" />
-            <label htmlFor="optsStep2Opt5">Navigazione del sito</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep2" type="radio" id="optsStep2Opt6" value="posta elettronica" />
-            <label htmlFor="optsStep2Opt6">Posta elettronica</label>
-          </div>
-          <div className="form-check form-check-group">
-            <input name="optsStep2" type="radio" id="optsStep2Opt7" value="altro" />
-            <label htmlFor="optsStep2Opt7">Altro</label>
-          </div>
-        </div>
-      </fieldset>
-
-      <fieldset onChange={e => setDetails(e.target.value)}>
-        <legend className="d-flex pt-5 pb-4 px-0 align-items-center w-75">
-          <Icon {...ICON_INFO} />
-          <span className="text-secondary">Come possiamo migliorare questa pagina?</span>
-        </legend>
-        <div className="px-3 px-lg-5 pt-5 pb-1 rounded shadow-lg">
-          <div className="form-group">
-            <LabelTextArea ariadescribedby="helperText" id="feedbackText" label="Risposta" rows="3" maxLength="200" />
-            <small id="helperText" className="form-control form-text">Hai a disposizione 200 caratteri. Per favore non inserire dati personali in questo campo.</small>
-          </div>
-        </div>
-      </fieldset>
-
-      <div className="mt-5">
-        <button
-          type="button"
-          className="btn btn-primary"
-          disabled={(!who && !from && !details) || state === FeedbackState.Loading}
-          onClick={handleClick}
-        >
-          {state === FeedbackState.Loading ? (
-            <>
-            <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
-            <span className="sr-only">Invio in corso...</span>
-            </>
-          ) : (
-            "Invia dettagli"
-          )}
-        </button>
-      </div>
-    </form>
-  </div>
+      </form>
+    </div>
+  );
 }
 
-export default FormNo
+export default FormNo;

--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -1,77 +1,83 @@
-import React, { useCallback, useState, useRef } from "react"
-import { Modal } from "bootstrap-italia"
-import "./feedback.scss"
-import Icon from "../icon/icon"
+import React, { useCallback, useState, useRef } from "react";
+import { Modal } from "bootstrap-italia";
+import "./feedback.scss";
+import Icon from "../icon/icon";
 
-import FeedbackState from "./state"
-import FormNo from "./components/form-no/FormNo"
+import FeedbackState from "./state";
+import FormNo from "./components/form-no/FormNo";
 
 const BTN_INTRO = {
   label: "Invia",
   btnStyle: "primary",
   type: "button",
-}
+};
 
 const ICON_CLOSE = {
   icon: "sprites.svg#it-close",
   color: "primary",
   size: "lg",
-}
+};
 
 const ICON_RESULT = {
   color: "primary",
   size: "lg",
-  align : "middle",
-  addonClasses: "me-2"
-}
+  align: "middle",
+  addonClasses: "me-2",
+};
 
 function Feedback() {
-  const [isChecked, setIsChecked] = useState(false)
-  const [feedbackState, setFeedbackState] = useState(FeedbackState.Start)
-  const [choiceVal, setChoiceVal] = useState("")
-  const [modal, setModal] = useState(null)
+  const [isChecked, setIsChecked] = useState(false);
+  const [feedbackState, setFeedbackState] = useState(FeedbackState.Start);
+  const [choiceVal, setChoiceVal] = useState("");
+  const [modal, setModal] = useState(null);
 
-  const modalNo = useRef(null)
+  const modalNo = useRef(null);
 
-  const sendFeedback = useCallback(async (result = {}) => {
-    setFeedbackState(FeedbackState.Loading);
-    const feedback = choiceVal === "1" ? '+' : '-';
+  const sendFeedback = useCallback(
+    async (result = {}) => {
+      setFeedbackState(FeedbackState.Loading);
+      const feedback = choiceVal === "1" ? "+" : "-";
 
-    try {
-      const r = await fetch("https://feedback.designers.italia.it/api/messages", {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          feedback,
-          url: window.location.href,
-          ...result,
-        }),
-      });
+      try {
+        const r = await fetch(
+          "https://feedback.designers.italia.it/api/messages",
+          {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              feedback,
+              url: window.location.href,
+              ...result,
+            }),
+          },
+        );
 
-      if (!r.ok) {
-        throw new Error(`HTTP response: ${r.status}`);
+        if (!r.ok) {
+          throw new Error(`HTTP response: ${r.status}`);
+        }
+      } catch (e) {
+        setFeedbackState(FeedbackState.Error);
+        console.error(`Feedback request error: ${e}`);
+
+        return false;
       }
-    } catch (e) {
-      setFeedbackState(FeedbackState.Error);
-      console.error(`Feedback request error: ${e}`);
 
-      return false;
-    }
+      setFeedbackState(FeedbackState.Success);
 
-    setFeedbackState(FeedbackState.Success);
-
-    return true;
-  }, [choiceVal]);
+      return true;
+    },
+    [choiceVal],
+  );
 
   const onChange = (evt) => {
     if (evt.currentTarget.checked) {
-      setIsChecked(true)
-      setChoiceVal(evt.currentTarget.value)
+      setIsChecked(true);
+      setChoiceVal(evt.currentTarget.value);
     }
-  }
+  };
 
   const openModal = () => {
     if (choiceVal === "0") {
@@ -80,7 +86,7 @@ function Feedback() {
 
       setModal(dialog);
     }
-  }
+  };
 
   const onSend = async () => {
     const res = await sendFeedback();
@@ -88,73 +94,111 @@ function Feedback() {
     if (res) {
       openModal();
     }
-  }
+  };
 
-  const onModalResult = useCallback(async (result) => {
-    await sendFeedback(result);
+  const onModalResult = useCallback(
+    async (result) => {
+      await sendFeedback(result);
 
-    modal.hide()
-  }, [modal, sendFeedback]);
+      modal.hide();
+    },
+    [modal, sendFeedback],
+  );
 
   const renderState = (state) => {
-    switch(state) {
+    switch (state) {
       case FeedbackState.Loading:
-      case FeedbackState.Start: return (
-        <>
-          <h2 className="mb-0 h5 fw-semibold" id="feedbackSectionTitle">
-            <span className="feedback-title">Ciao, questa pagina è stata utile?</span>
-          </h2>
-          <form className="mt-3 mt-md-3">
-            <fieldset className="d-flex">
-              <legend>
-                <span className="visually-hidden">Scegli la risposta:</span>
-              </legend>
-              <div className="form-check me-4">
-                <input name="feedbackValue" type="radio" id="feedbackValueYes" value="1" onChange={onChange} />
-                <label className="mb-0" htmlFor="feedbackValueYes">Sì</label>
-              </div>
-              <div className="form-check">
-                <input name="feedbackValue" type="radio" id="feedbackValueNo" value="0" onChange={onChange} />
-                <label className="mb-0" htmlFor="feedbackValueNo">No</label>
-              </div>
-            </fieldset>
+      case FeedbackState.Start:
+        return (
+          <>
+            <h2 className="mb-0 h5 fw-semibold" id="feedbackSectionTitle">
+              <span className="feedback-title">
+                Ciao, questa pagina è stata utile?
+              </span>
+            </h2>
+            <form className="mt-3 mt-md-3">
+              <fieldset className="d-flex">
+                <legend>
+                  <span className="visually-hidden">Scegli la risposta:</span>
+                </legend>
+                <div className="form-check me-4">
+                  <input
+                    name="feedbackValue"
+                    type="radio"
+                    id="feedbackValueYes"
+                    value="1"
+                    onChange={onChange}
+                  />
+                  <label className="mb-0" htmlFor="feedbackValueYes">
+                    Sì
+                  </label>
+                </div>
+                <div className="form-check">
+                  <input
+                    name="feedbackValue"
+                    type="radio"
+                    id="feedbackValueNo"
+                    value="0"
+                    onChange={onChange}
+                  />
+                  <label className="mb-0" htmlFor="feedbackValueNo">
+                    No
+                  </label>
+                </div>
+              </fieldset>
 
-            <button
-              type="button"
-              className="btn btn-primary mt-4"
-              disabled={!isChecked || feedbackState === FeedbackState.Loading}
-              onClick={onSend}
-            >
-              {feedbackState === FeedbackState.Loading ? (
-                <>
-                  <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
-                  <span className="sr-only">Invio in corso...</span>
-                </>
-              ) : (
-                BTN_INTRO.label
-              )}
-            </button>
-          </form>
-        </>
-        )
-      case FeedbackState.Success: return (
+              <button
+                type="button"
+                className="btn btn-primary mt-4"
+                disabled={!isChecked || feedbackState === FeedbackState.Loading}
+                onClick={onSend}
+              >
+                {feedbackState === FeedbackState.Loading ? (
+                  <>
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      role="status"
+                      aria-hidden="true"
+                    />
+                    <span className="sr-only">Invio in corso...</span>
+                  </>
+                ) : (
+                  BTN_INTRO.label
+                )}
+              </button>
+            </form>
+          </>
+        );
+      case FeedbackState.Success:
+        return (
           <span className="feedback-confirm d-flex align-items-center">
             <Icon icon="sprites.svg#it-check-circle" {...ICON_RESULT} />
             Feedback inviato. Grazie.
           </span>
-        )
-      case FeedbackState.Error: return (
+        );
+      case FeedbackState.Error:
+        return (
           <span className="feedback-confirm d-flex align-items-center">
-            <Icon {...ICON_RESULT} icon="sprites.svg#it-error" addonClasses="icon-danger me-2" />
-            C’è stato un problema nell’invio 😞<br/> Ti va di riprovare più tardi? 🙏
+            <Icon
+              {...ICON_RESULT}
+              icon="sprites.svg#it-error"
+              addonClasses="icon-danger me-2"
+            />
+            C’è stato un problema nell’invio 😞
+            <br /> Ti va di riprovare più tardi? 🙏
           </span>
-        )
-      default: return null // should not happen
+        );
+      default:
+        return null; // should not happen
     }
   };
 
   return (
-    <section className="feedback bg-medium py-5 px-3 px-lg-0" aria-labelledby="feedbackSectionTitle" id="feedbackSection">
+    <section
+      className="feedback bg-medium py-5 px-3 px-lg-0"
+      aria-labelledby="feedbackSectionTitle"
+      id="feedbackSection"
+    >
       <div className="container-xxl">
         <div className="row d-flex justify-content-center">
           <div className="col-12 col-sm-10 col-md-8 col-lg-6">
@@ -171,11 +215,26 @@ function Feedback() {
         </div>
       </div>
 
-      <div ref={modalNo} className="modal fade" tabIndex="-1" role="dialog" id="feedbackNo" aria-labelledby="feedbackNoTitle">
-        <div className="modal-dialog modal-lg modal-dialog-centered " role="document">
+      <div
+        ref={modalNo}
+        className="modal fade"
+        tabIndex="-1"
+        role="dialog"
+        id="feedbackNo"
+        aria-labelledby="feedbackNoTitle"
+      >
+        <div
+          className="modal-dialog modal-lg modal-dialog-centered "
+          role="document"
+        >
           <div className="modal-content">
             <div className="modal-header align-items-start">
-              <button className="btn-close flex-shrink-0" type="button" data-bs-dismiss="modal" aria-label="Chiudi finestra modale">
+              <button
+                className="btn-close flex-shrink-0"
+                type="button"
+                data-bs-dismiss="modal"
+                aria-label="Chiudi finestra modale"
+              >
                 <Icon {...ICON_CLOSE} />
               </button>
             </div>
@@ -185,9 +244,8 @@ function Feedback() {
           </div>
         </div>
       </div>
-
     </section>
-  )
+  );
 }
 
-export default Feedback
+export default Feedback;

--- a/src/components/feedback/state.js
+++ b/src/components/feedback/state.js
@@ -1,6 +1,6 @@
 export default Object.freeze({
-  Start: 'start',
-  Loading: 'loading',
-  Success: 'success',
-  Error: 'error',
+  Start: "start",
+  Loading: "loading",
+  Success: "success",
+  Error: "error",
 });

--- a/src/components/filter-cards/filter-cards.js
+++ b/src/components/filter-cards/filter-cards.js
@@ -2,7 +2,7 @@ import React from "react";
 import Card from "../card/card";
 import ListArchiveDSTags from "../list-archive-ds-tags/list-archive-ds-tags";
 
-import "./filter-cards.scss"
+import "./filter-cards.scss";
 
 function FilterCards({
   id,
@@ -12,33 +12,32 @@ function FilterCards({
   cards,
   showTags,
   col2,
-  noSpace
+  noSpace,
 }) {
+  const styles =
+    "filter-cards px-3 p-md-0" +
+    `${background ? ` bg-${background}` : ""}` +
+    `${noSpace ? "" : " py-5 py-lg-6"}` +
+    `${col2 ? " two-columns" : ""}`;
 
-  const styles = 'filter-cards px-3 p-md-0'
-    + `${background ? ` bg-${  background}` : ''}`
-    + `${noSpace ? '' : ' py-5 py-lg-6'}`
-    + `${col2 ? ' two-columns' : ''}`
+  const cardStyles = `col-12 col-md-6 mb-3 mb-md-4 ${col2 ? "" : " col-lg-4"}`;
 
-  const cardStyles = 'col-12 col-md-6 mb-3 mb-md-4'
-    + `${col2 ? '' : ' col-lg-4'}`
-
-  let cardsItems
+  let cardsItems;
 
   // heading level
-  let HLevel
+  let HLevel;
   if (headingLevel) {
     HLevel = `h${headingLevel}`;
   } else {
-    HLevel = `h2`
+    HLevel = `h2`;
   }
 
   if (cards) {
     cardsItems = cards.map((item, index) => (
-        <div className={cardStyles} key={`cardcol-${  index}`}>
-          <Card {...item} />
-        </div>
-      ))
+      <div className={cardStyles} key={`cardcol-${index}`}>
+        <Card {...item} />
+      </div>
+    ));
   }
 
   return (
@@ -49,20 +48,12 @@ function FilterCards({
             {title && <HLevel id={id}>{title}</HLevel>}
           </div>
 
-          {showTags &&
-            <ListArchiveDSTags />
-          }
-
+          {showTags && <ListArchiveDSTags />}
         </div>
-        <div className="row cards-wrapper">
-          {cardsItems}
-        </div>
+        <div className="row cards-wrapper">{cardsItems}</div>
       </div>
-
-
     </section>
-  )
+  );
 }
 
-
-export default FilterCards
+export default FilterCards;

--- a/src/components/footer-brand/footer-brand.js
+++ b/src/components/footer-brand/footer-brand.js
@@ -1,21 +1,18 @@
-import React from "react"
-import ReactMarkdown from "react-markdown"
-import ImageResponsive from "../image-responsive/image-responsive"
-import Link from "../link/link"
-import "./footer-brand.scss"
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import ImageResponsive from "../image-responsive/image-responsive";
+import Link from "../link/link";
+import "./footer-brand.scss";
 
-function FooterBrand({
-  background,
-  title,
-  justifyLogos,
-  logos
-}) {
-  const styles = 'footer-brand pt-5 pb-4'
-    + `${background ? ` bg-${background}` : ''}`
-    + `${background === "dark" || background === "primary" ? ' text-white' : ''}`
+function FooterBrand({ background, title, justifyLogos, logos }) {
+  const styles =
+    "footer-brand pt-5 pb-4" +
+    `${background ? ` bg-${background}` : ""}` +
+    `${background === "dark" || background === "primary" ? " text-white" : ""}`;
 
-  const logosStyles = 'logos list-unstyled d-flex flex-column flex-md-row flex-wrap align-items-center mb-0'
-    + `${justifyLogos ? ' justify-content-md-between' : ''}`
+  const logosStyles =
+    "logos list-unstyled d-flex flex-column flex-md-row flex-wrap align-items-center mb-0" +
+    `${justifyLogos ? " justify-content-md-between" : ""}`;
 
   return (
     <div className={styles}>
@@ -28,25 +25,29 @@ function FooterBrand({
         <div className="row">
           <div className="col px-4">
             <ul className={logosStyles}>
-              {logos.map((value,index)=>(
-                  <li key={`item-${index}`} className="mb-5 me-md-5 ">
-                    <Link
-                      to={value.url}
-                      target={value.blank ? "_blank" : undefined}
-                      rel={value.blank ? 'noreferrer' : undefined}
-                      className="d-block"
-                      aria-label={value.ariaLabel}
-                    >
-                      <ImageResponsive src={value.img} alt="" className={value.small ? "small" : undefined}/> 
-                    </Link>
-                  </li>
-                ))}
+              {logos.map((value, index) => (
+                <li key={`item-${index}`} className="mb-5 me-md-5 ">
+                  <Link
+                    to={value.url}
+                    target={value.blank ? "_blank" : undefined}
+                    rel={value.blank ? "noreferrer" : undefined}
+                    className="d-block"
+                    aria-label={value.ariaLabel}
+                  >
+                    <ImageResponsive
+                      src={value.img}
+                      alt=""
+                      className={value.small ? "small" : undefined}
+                    />
+                  </Link>
+                </li>
+              ))}
             </ul>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default FooterBrand
+export default FooterBrand;

--- a/src/components/footer-main/footer-main.js
+++ b/src/components/footer-main/footer-main.js
@@ -1,127 +1,134 @@
-import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
-import List from "../list/list"
-import ListItem from "../list-item/list-item"
-import Button from "../button/button"
-import Subscribe from "../subscribe/subscribe"
-import Link from "../link/link"
-import "./footer-main.scss"
+import React from "react";
+import { useStaticQuery, graphql } from "gatsby";
+import List from "../list/list";
+import ListItem from "../list-item/list-item";
+import Button from "../button/button";
+import Subscribe from "../subscribe/subscribe";
+import Link from "../link/link";
+import "./footer-main.scss";
 
-import Chip from "../chip/chip"
+import Chip from "../chip/chip";
 
-function FooterMain({
-  id,
-  title,
-  cols,
-  tagsNo,
-  social,
-  community,
-  subscribe
-}) {
-
+function FooterMain({ id, title, cols, tagsNo, social, community, subscribe }) {
   const data = useStaticQuery(graphql`
-  query {
-    footerTags: allContent {
-      group(field: { components: { hero: { kangaroo: { tags: SELECT } } } }) {
-        fieldValue
-        totalCount
+    query {
+      footerTags: allContent {
+        group(field: { components: { hero: { kangaroo: { tags: SELECT } } } }) {
+          fieldValue
+          totalCount
+        }
       }
     }
-  }
-  `)
+  `);
 
-  data.footerTags.group.sort((a, b) => parseFloat(b.totalCount) - parseFloat(a.totalCount));
-  const footerTags = data.footerTags.group.slice(0, tagsNo)
+  data.footerTags.group.sort(
+    (a, b) => parseFloat(b.totalCount) - parseFloat(a.totalCount),
+  );
+  const footerTags = data.footerTags.group.slice(0, tagsNo);
 
   return (
     <div className="it-footer-main py-5" id={id}>
       <div className="container-xxl">
         <section>
-          {title &&
+          {title && (
             <div className="row clearfix pb-4">
               <div className="col-12">
                 <h3 className="footer-title">{title}</h3>
               </div>
             </div>
-          }
+          )}
         </section>
         <section>
-
-          {footerTags && <div className="row">
-            <div className="chips-list-wrapper">
-              <ul className="chips-list chips d-flex flex-wrap">
-                {footerTags.map(tag => (
-                  <ListItem key={tag.fieldValue} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
-                    <Chip label={tag.fieldValue} size="lg" color="primary" />
-                  </ListItem>
-                ))}
-              </ul>
-              <div className="text-end">
-                <Link className="text-white" to="/argomenti/"><strong>Scopri tutti gli argomenti</strong></Link>
+          {footerTags && (
+            <div className="row">
+              <div className="chips-list-wrapper">
+                <ul className="chips-list chips d-flex flex-wrap">
+                  {footerTags.map((tag) => (
+                    <ListItem
+                      key={tag.fieldValue}
+                      addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+                    >
+                      <Chip label={tag.fieldValue} size="lg" color="primary" />
+                    </ListItem>
+                  ))}
+                </ul>
+                <div className="text-end">
+                  <Link className="text-white" to="/argomenti/">
+                    <strong>Scopri tutti gli argomenti</strong>
+                  </Link>
+                </div>
               </div>
             </div>
-          </div>
-          }
+          )}
 
-          {cols && <div className="row">
-            {cols.map((value, index) => (
-                <div key={`item-${  index}`} className="col-12 col-md-6 col-lg-3 col-sm-6 pb-mb-2 pb-lg-0">
+          {cols && (
+            <div className="row">
+              {cols.map((value, index) => (
+                <div
+                  key={`item-${index}`}
+                  className="col-12 col-md-6 col-lg-3 col-sm-6 pb-mb-2 pb-lg-0"
+                >
                   <List {...value}>
                     {value.items.map((item, index) => (
-                        <ListItem {...item} key={`subitem-${  index}`} />
-                      ))}
+                      <ListItem {...item} key={`subitem-${index}`} />
+                    ))}
                   </List>
                 </div>
               ))}
-          </div>
-          }
-
+            </div>
+          )}
         </section>
         <section className="footer-utilities mt-5 pt-5">
           <div className="row">
-
-            {community &&
+            {community && (
               <div className="col-12 col-md-6 col-lg-3 mb-5 mb-lg-0">
                 <h3 className="footer-title pb-4">{community.title}</h3>
 
                 <List {...community.list}>
                   {community.list.items.map((item, index) => (
-                      <ListItem {...item} key={`subitem-${  index}`} />
-                    ))}
+                    <ListItem {...item} key={`subitem-${index}`} />
+                  ))}
                 </List>
               </div>
-            }
+            )}
 
-            {social &&
+            {social && (
               <div className="col-12 col-md-6 col-lg-3 mb-5 mb-lg-0">
                 <h3 className="footer-title pb-4">{social.title}</h3>
                 {social.buttons.map((button, index) => (
-                    <Button key={`social-${  index}`} {...button} />
-                  ))}
+                  <Button key={`social-${index}`} {...button} />
+                ))}
               </div>
-            }
+            )}
 
-
-            {subscribe &&
+            {subscribe && (
               <div className="col-12 col-lg-6">
                 <div className="title-wrapper d-flex justify-content-between">
                   <h3 className="footer-title pb-4">{subscribe.title}</h3>
-                  {subscribe.link &&
-                    <Link className="text-white" to={subscribe.link.url} target="_blank" rel="noreferrer" aria-label={subscribe.link.ariaLabel}>{subscribe.link.label}</Link>
-                  }
+                  {subscribe.link && (
+                    <Link
+                      className="text-white"
+                      to={subscribe.link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={subscribe.link.ariaLabel}
+                    >
+                      {subscribe.link.label}
+                    </Link>
+                  )}
                 </div>
-                {subscribe.subscribe &&
+                {subscribe.subscribe && (
                   <div className="subscribe-wrapper mt-4">
                     <Subscribe {...subscribe.subscribe} />
                   </div>
-                }
+                )}
               </div>
-            }
+            )}
           </div>
         </section>
       </div>
     </div>
-  )
+  );
 }
 
-export default FooterMain
+export default FooterMain;

--- a/src/components/footer-small/footer-small.js
+++ b/src/components/footer-small/footer-small.js
@@ -1,29 +1,29 @@
-import React from "react"
-import Link from "../link/link"
-import "./footer-small.scss"
+import React from "react";
+import Link from "../link/link";
+import "./footer-small.scss";
 
-function FooterSmall({
-  items
-}) {
+function FooterSmall({ items }) {
   return (
     <div className="it-footer-small-prints clearfix">
       <div className="container-xxl">
         <h3 className="visually-hidden text-white">Sezione Link Utili</h3>
         <ul className="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row">
-          {items.map((value,index)=>(
-              <li key={`foot-item-${index}`} className="list-inline-item" >
-                <Link
-                  to={value.url}
-                  target={value.blank ? "_blank" : undefined}
-                  rel={value.blank ? 'noreferrer' : undefined}
-                  aria-label={value.ariaLabel}
-                >{value.title}</Link>
-              </li>
-            ))}
+          {items.map((value, index) => (
+            <li key={`foot-item-${index}`} className="list-inline-item">
+              <Link
+                to={value.url}
+                target={value.blank ? "_blank" : undefined}
+                rel={value.blank ? "noreferrer" : undefined}
+                aria-label={value.ariaLabel}
+              >
+                {value.title}
+              </Link>
+            </li>
+          ))}
         </ul>
       </div>
     </div>
-  )
+  );
 }
 
-export default FooterSmall
+export default FooterSmall;

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -1,8 +1,7 @@
-import React from "react"
-import FooterBrand from "../footer-brand/footer-brand"
-import FooterMain from "../footer-main/footer-main"
-import FooterSmall from "../footer-small/footer-small"
-
+import React from "react";
+import FooterBrand from "../footer-brand/footer-brand";
+import FooterMain from "../footer-main/footer-main";
+import FooterSmall from "../footer-small/footer-small";
 
 function Footer({
   title,
@@ -11,16 +10,15 @@ function Footer({
   footerMain,
   footerSmall,
 }) {
-
   return (
-	<footer className="it-footer">
-    <h2 className="visually-hidden">{title}</h2>
-    {footerProject && <FooterBrand {...footerProject}/>}
-    {footerContribute && <FooterBrand {...footerContribute}/>}
-    {footerMain && <FooterMain {...footerMain}/>}
-    {footerSmall && <FooterSmall {...footerSmall}/>}
-	</footer>
-  )
+    <footer className="it-footer">
+      <h2 className="visually-hidden">{title}</h2>
+      {footerProject && <FooterBrand {...footerProject} />}
+      {footerContribute && <FooterBrand {...footerContribute} />}
+      {footerMain && <FooterMain {...footerMain} />}
+      {footerSmall && <FooterSmall {...footerSmall} />}
+    </footer>
+  );
 }
 
-export default Footer
+export default Footer;

--- a/src/components/header-center/header-center.js
+++ b/src/components/header-center/header-center.js
@@ -1,22 +1,24 @@
-import React from "react"
-import Link from "../link/link"
-import Icon from "../icon/icon"
-import ImageResponsive from "../image-responsive/image-responsive"
-import "./header-center.scss"
+import React from "react";
+import Link from "../link/link";
+import Icon from "../icon/icon";
+import ImageResponsive from "../image-responsive/image-responsive";
+import "./header-center.scss";
 
-
-function HeaderCenter({data}) {
-
+function HeaderCenter({ data }) {
   // eslint-disable-next-line consistent-return
   function search(boolean) {
     if (boolean) {
-      return(
+      return (
         <div className="it-search-wrapper">
-          <Link className="search-link rounded-icon" aria-label={data.search.title} to={data.search.url}>
-            <Icon icon={data.search.icon}/>
+          <Link
+            className="search-link rounded-icon"
+            aria-label={data.search.title}
+            to={data.search.url}
+          >
+            <Icon icon={data.search.icon} />
           </Link>
         </div>
-      )
+      );
     }
   }
 
@@ -27,28 +29,35 @@ function HeaderCenter({data}) {
         <div className="it-socials d-none d-md-flex">
           <span>{data.socials.title}</span>
           <ul>
-            {data.socials.items.map((value,index)=>(
-                <li key={`social-item-${index}`}>
-                  <Link to={value.url} aria-label={value.title} target="_blank" rel="noreferrer">
-                    <Icon icon={value.icon}/>
-                  </Link>
-                </li>
-              ))}
+            {data.socials.items.map((value, index) => (
+              <li key={`social-item-${index}`}>
+                <Link
+                  to={value.url}
+                  aria-label={value.title}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <Icon icon={value.icon} />
+                </Link>
+              </li>
+            ))}
           </ul>
         </div>
-      )
+      );
     }
   }
 
   return (
-    <div className="it-header-center-wrapper "> {/* it-small-header */}
+    <div className="it-header-center-wrapper ">
+      {" "}
+      {/* it-small-header */}
       <div className="container-xxl">
         <div className="row">
           <div className="col-12">
             <div className="it-header-center-content-wrapper">
               <div className="it-brand-wrapper">
                 <Link to="/">
-                  <ImageResponsive src={data.logo} alt="" imgClassName="icon"/>
+                  <ImageResponsive src={data.logo} alt="" imgClassName="icon" />
                   <div className="it-brand-text">
                     <div className="it-brand-title">{data.title}</div>
                   </div>
@@ -63,7 +72,7 @@ function HeaderCenter({data}) {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default HeaderCenter
+export default HeaderCenter;

--- a/src/components/header-menu-item/header-menu-item.js
+++ b/src/components/header-menu-item/header-menu-item.js
@@ -1,20 +1,12 @@
-import * as React from "react"
+import * as React from "react";
 
-function HeaderMenuItem({
-	isDropDown,
-	isMegaMenu,
-	children
-}) {
+function HeaderMenuItem({ isDropDown, isMegaMenu, children }) {
+  const styles =
+    "nav-item" +
+    `${isDropDown ? " dropdown" : ""}` +
+    `${isMegaMenu ? " megamenu" : ""}`;
 
-	const styles = "nav-item"
-		+ `${isDropDown ? ' dropdown' : ''}`
-		+ `${isMegaMenu ? ' megamenu' : ''}`
-	
-		return(
-		<li className={styles}>
-			{children}
-		</li>
-	)
+  return <li className={styles}>{children}</li>;
 }
 
-export default HeaderMenuItem
+export default HeaderMenuItem;

--- a/src/components/header-menu-link/header-menu-link.js
+++ b/src/components/header-menu-link/header-menu-link.js
@@ -1,65 +1,57 @@
-import * as React from "react"
+import * as React from "react";
 import { useEffect } from "react";
-import {Dropdown} from "bootstrap-italia"
-import "./header-menu-link.scss"
+import { Dropdown } from "bootstrap-italia";
+import "./header-menu-link.scss";
 
 import { Link } from "gatsby";
-import Icon from "../icon/icon"
+import Icon from "../icon/icon";
 
-function HeaderMenuLink({
-	isDropDown,
-	idMegamenu,
-	label,
-	url,
-	page
-}) {
-
+function HeaderMenuLink({ isDropDown, idMegamenu, label, url, page }) {
   useEffect(() => {
     // eslint-disable-next-line no-new
-    new Dropdown(document.getElementById(idMegamenu), {})
+    new Dropdown(document.getElementById(idMegamenu), {});
   });
 
-	const styles = 'nav-link'
-		+ `${isDropDown ? ' dropdown-toggle' : ''}`
-		+ `${page===label ? ' active' : ''}`
-		+ ' px-lg-2 px-xl-3 fw-semibold'
+  const styles =
+    "nav-link" +
+    `${isDropDown ? " dropdown-toggle" : ""}` +
+    `${page === label ? " active" : ""}` +
+    " px-lg-2 px-xl-3 fw-semibold";
 
   // eslint-disable-next-line consistent-return
-	function icon(boolean){
-		if (boolean) {
-			return (
-				<Icon icon="sprites.svg#it-expand" size="xs" addonClasses="ms-1"/>
-			)
-		}
-	}
+  function icon(boolean) {
+    if (boolean) {
+      return (
+        <Icon icon="sprites.svg#it-expand" size="xs" addonClasses="ms-1" />
+      );
+    }
+  }
 
   if (isDropDown) {
     return (
       <button
         type="button"
         className={styles}
-        data-bs-toggle={isDropDown ? 'dropdown' : undefined}
-        aria-expanded={isDropDown ? 'false' : undefined}
+        data-bs-toggle={isDropDown ? "dropdown" : undefined}
+        aria-expanded={isDropDown ? "false" : undefined}
         id={idMegamenu}
-        >
+      >
         <span>{label}</span>
         {icon(isDropDown)}
       </button>
-    )
+    );
   }
-    return (
-      <Link
-        className={styles}
-        href={url || '#'}
-        data-bs-toggle={isDropDown ? 'dropdown' : undefined}
-        aria-expanded={isDropDown ? 'false' : undefined}
-        id={idMegamenu}
-        >
-        <span>{label}</span>
-        {icon(isDropDown)}
-      </Link>
-    )
-
-
+  return (
+    <Link
+      className={styles}
+      href={url || "#"}
+      data-bs-toggle={isDropDown ? "dropdown" : undefined}
+      aria-expanded={isDropDown ? "false" : undefined}
+      id={idMegamenu}
+    >
+      <span>{label}</span>
+      {icon(isDropDown)}
+    </Link>
+  );
 }
-export default HeaderMenuLink
+export default HeaderMenuLink;

--- a/src/components/header-menu/header-menu.js
+++ b/src/components/header-menu/header-menu.js
@@ -1,11 +1,7 @@
-import * as React from "react"
+import * as React from "react";
 
-function HeaderMenu({children}) {
-	return(
-			<ul className="navbar-nav">
-				{children}
-			</ul>
-	)
+function HeaderMenu({ children }) {
+  return <ul className="navbar-nav">{children}</ul>;
 }
 
-export default HeaderMenu
+export default HeaderMenu;

--- a/src/components/header-nav/header-nav.js
+++ b/src/components/header-nav/header-nav.js
@@ -1,93 +1,154 @@
-import React, { useEffect, useRef } from "react"
-import { NavBarCollapsible } from "bootstrap-italia"
-import Button from "../button/button"
-import Icon from "../icon/icon"
-import HeaderMenu from "../header-menu/header-menu"
-import HeaderMenuItem from "../header-menu-item/header-menu-item"
-import HeaderMenuLink from "../header-menu-link/header-menu-link"
-import DropdownMenu from "../dropdown-menu/dropdown-menu"
-import Megamenu from "../megamenu/megamenu"
-import "./header-nav.scss"
+import React, { useEffect, useRef } from "react";
+import { NavBarCollapsible } from "bootstrap-italia";
+import Button from "../button/button";
+import Icon from "../icon/icon";
+import HeaderMenu from "../header-menu/header-menu";
+import HeaderMenuItem from "../header-menu-item/header-menu-item";
+import HeaderMenuLink from "../header-menu-link/header-menu-link";
+import DropdownMenu from "../dropdown-menu/dropdown-menu";
+import Megamenu from "../megamenu/megamenu";
+import "./header-nav.scss";
 
-function HeaderNav({
-  data,
-  page
-}) {
-
-  const collRef = useRef(null)
-  const navBar = useRef(null)
+function HeaderNav({ data, page }) {
+  const collRef = useRef(null);
+  const navBar = useRef(null);
 
   useEffect(() => {
-    navBar.current = new NavBarCollapsible(collRef.current)
+    navBar.current = new NavBarCollapsible(collRef.current);
     return () => {
       if (navBar.current) {
-        navBar.current.hide()
+        navBar.current.hide();
         // document.scrollingElement.scrollTop = 0 //reset page scroll
       }
-    }
-  })
+    };
+  });
 
-	return(
-	<div className="it-header-navbar-wrapper {data.theme}" id={data.id}>
-		<div className="container-xxl">
-			<div className="row">
-				<div className="col-12">
-					<nav className="navbar navbar-expand-lg has-megamenu" aria-label={data.ariaLabel}>
-						<Button customStyle="custom-navbar-toggler" type="button" dataBsToggle="navbarcollapsible" ariaControls={data.nav.id} ariaExpanded="false" ariaLabel={data.toggler.ariaLabel}>
-							<Icon icon="sprites.svg#it-burger"/>
-						</Button>
-						<div className="navbar-collapsable" ref={collRef} id={data.nav.id}>
-							<div className="overlay" />
-							<div className="close-div">
-								<Button addonStyle="close-menu" ariaLabel={data.close.ariaLabel}>
-									<Icon icon="sprites.svg#it-close-big"/>
-								</Button>
-							</div>
-							<div className="menu-wrapper justify-content-lg-between">
-								<HeaderMenu>
-									{data.nav.voicesLeft.map((value,index)=>(
-											<HeaderMenuItem key={`item-header-${index}`} isDropDown={value.isDropDown} isMegaMenu={value.isMegaMenu}>
-												<HeaderMenuLink key={`item-menu-${index}`} isDropDown={value.isDropDown} label={value.label} idMegamenu={value.idMegamenu} page={page} />
-												<DropdownMenu key={`dropDown-${index}`} idMegamenu={value.idMegamenu}>
-													{value.megamenu &&
-														<Megamenu key={`mega-${index}`} {...value.megamenu} />
-													}
-												</DropdownMenu>
-											</HeaderMenuItem>
-										))}
-								</HeaderMenu>
-								<HeaderMenu>
-									{data.nav.voicesCenter.map((value,index)=>(
-											<HeaderMenuItem key={`item-header-${index}`} isDropDown={value.isDropDown} isMegaMenu={value.isMegaMenu}>
-												<HeaderMenuLink key={`item-menu-${index}`} isDropDown={value.isDropDown} label={value.label} idMegamenu={value.idMegamenu} page={page} />
-												<DropdownMenu key={`dropDown-${index}`} idMegamenu={value.idMegamenu}>
-													{value.megamenu &&
-														<Megamenu key={`mega-${index}`} {...value.megamenu} />
-													}
-												</DropdownMenu>
-											</HeaderMenuItem>
-										))}
-								</HeaderMenu>
-								<HeaderMenu>
-									{data.nav.voicesRight.map((value,index)=>(
-											<HeaderMenuItem key={`item-header-${index}`} isDropDown={value.isDropDown} isMegaMenu={value.isMegaMenu}>
-												<HeaderMenuLink key={`item-menu-${index}`} isDropDown={value.isDropDown} label={value.label} idMegamenu={value.idMegamenu} page={page} />
-												<DropdownMenu key={`dropDown-${index}`} idMegamenu={value.idMegamenu}>
-													{value.megamenu &&
-														<Megamenu key={`mega-${index}`} {...value.megamenu} />
-													}
-												</DropdownMenu>
-											</HeaderMenuItem>
-										))}
-								</HeaderMenu>
-							</div>
-						</div>
-					</nav>
-				</div>
-			</div>
-		</div>
-	</div>
-	)
+  return (
+    <div className="it-header-navbar-wrapper {data.theme}" id={data.id}>
+      <div className="container-xxl">
+        <div className="row">
+          <div className="col-12">
+            <nav
+              className="navbar navbar-expand-lg has-megamenu"
+              aria-label={data.ariaLabel}
+            >
+              <Button
+                customStyle="custom-navbar-toggler"
+                type="button"
+                dataBsToggle="navbarcollapsible"
+                ariaControls={data.nav.id}
+                ariaExpanded="false"
+                ariaLabel={data.toggler.ariaLabel}
+              >
+                <Icon icon="sprites.svg#it-burger" />
+              </Button>
+              <div
+                className="navbar-collapsable"
+                ref={collRef}
+                id={data.nav.id}
+              >
+                <div className="overlay" />
+                <div className="close-div">
+                  <Button
+                    addonStyle="close-menu"
+                    ariaLabel={data.close.ariaLabel}
+                  >
+                    <Icon icon="sprites.svg#it-close-big" />
+                  </Button>
+                </div>
+                <div className="menu-wrapper justify-content-lg-between">
+                  <HeaderMenu>
+                    {data.nav.voicesLeft.map((value, index) => (
+                      <HeaderMenuItem
+                        key={`item-header-${index}`}
+                        isDropDown={value.isDropDown}
+                        isMegaMenu={value.isMegaMenu}
+                      >
+                        <HeaderMenuLink
+                          key={`item-menu-${index}`}
+                          isDropDown={value.isDropDown}
+                          label={value.label}
+                          idMegamenu={value.idMegamenu}
+                          page={page}
+                        />
+                        <DropdownMenu
+                          key={`dropDown-${index}`}
+                          idMegamenu={value.idMegamenu}
+                        >
+                          {value.megamenu && (
+                            <Megamenu
+                              key={`mega-${index}`}
+                              {...value.megamenu}
+                            />
+                          )}
+                        </DropdownMenu>
+                      </HeaderMenuItem>
+                    ))}
+                  </HeaderMenu>
+                  <HeaderMenu>
+                    {data.nav.voicesCenter.map((value, index) => (
+                      <HeaderMenuItem
+                        key={`item-header-${index}`}
+                        isDropDown={value.isDropDown}
+                        isMegaMenu={value.isMegaMenu}
+                      >
+                        <HeaderMenuLink
+                          key={`item-menu-${index}`}
+                          isDropDown={value.isDropDown}
+                          label={value.label}
+                          idMegamenu={value.idMegamenu}
+                          page={page}
+                        />
+                        <DropdownMenu
+                          key={`dropDown-${index}`}
+                          idMegamenu={value.idMegamenu}
+                        >
+                          {value.megamenu && (
+                            <Megamenu
+                              key={`mega-${index}`}
+                              {...value.megamenu}
+                            />
+                          )}
+                        </DropdownMenu>
+                      </HeaderMenuItem>
+                    ))}
+                  </HeaderMenu>
+                  <HeaderMenu>
+                    {data.nav.voicesRight.map((value, index) => (
+                      <HeaderMenuItem
+                        key={`item-header-${index}`}
+                        isDropDown={value.isDropDown}
+                        isMegaMenu={value.isMegaMenu}
+                      >
+                        <HeaderMenuLink
+                          key={`item-menu-${index}`}
+                          isDropDown={value.isDropDown}
+                          label={value.label}
+                          idMegamenu={value.idMegamenu}
+                          page={page}
+                        />
+                        <DropdownMenu
+                          key={`dropDown-${index}`}
+                          idMegamenu={value.idMegamenu}
+                        >
+                          {value.megamenu && (
+                            <Megamenu
+                              key={`mega-${index}`}
+                              {...value.megamenu}
+                            />
+                          )}
+                        </DropdownMenu>
+                      </HeaderMenuItem>
+                    ))}
+                  </HeaderMenu>
+                </div>
+              </div>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
-export default HeaderNav
+export default HeaderNav;

--- a/src/components/header-post/header-post.js
+++ b/src/components/header-post/header-post.js
@@ -1,74 +1,88 @@
-import React from "react"
-import ReactMarkdown from "react-markdown"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import "./header-post.scss"
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import "./header-post.scss";
 
-let styles
+let styles;
 
-const iconNewsletter = ({
-    icon: "sprites.svg#it-mail",
-    size: "sm",
-    align : "middle",
-    color :"primary",
-    hidden: true,
-    addonClasses: "ms-2"
-  })
+const iconNewsletter = {
+  icon: "sprites.svg#it-mail",
+  size: "sm",
+  align: "middle",
+  color: "primary",
+  hidden: true,
+  addonClasses: "ms-2",
+};
 
-function HeaderPost({data}) {
-	if (data.isActive){
-		return (
-			<section aria-labelledby={data.nav.id}>
-					<div className="it-header-slim-wrapper p-0 h-100">
-						<div className="header-pre bg-white border-bottom border-100 w-100 shadow-sm">
-							<div className="container-xxl">
-								<div className="row ">
-									<div className="col-12 g-0">
-										<div className="header-post-wrapper">
-											<span id={data.nav.id} className="visually-hidden">{data.nav.ariaLabel}</span>
-											<ul className="list-inline py-4 px-4 px-lg-5 mb-0 d-flex align-items-center flex-nowrap overflow-x-list">
-												{data.nav.items.map((value,index)=>{
-													if (index + 1 === data.nav.items.length) { // last on the left side has "me-auto"
-														styles="list-item text-nowrap me-5 me-md-auto"
-													} else {
-														styles="list-item text-nowrap me-5"
-													}
-													return(
-													<li key={`banner-item-${index}`} className={styles} >
-														<Link
-														to={value.url}
-														target={value.blank ? "_blank" : undefined}
-														rel={value.blank ? 'noreferrer' : undefined}
-														>
-															<Icon {...value.icon}/>
-															{value.title && <ReactMarkdown components={{ p: "span" }}>{value.title}</ReactMarkdown>}
-														</Link>
-													</li>
-													)
-												})}
-												<li key={`banner-item-${data.nav.items.length}${1}`} className="list-item text-nowrap ms-5 me-md-0">
-													<Link
-													className="simple-cta fw-semibold"
-													to={data.nav.newsletter.url}
-													target={data.nav.newsletter.blank ? "_blank" : undefined}
-													rel={data.nav.newsletter.blank ? 'noreferrer' : undefined}
-													>
-														<span className="text-end">
-															{data.nav.newsletter.title}
-														</span>
-														<Icon {...iconNewsletter}/>
-													</Link>
-												</li>
-											</ul>
-										</div>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</section>
-		)
-	}
+function HeaderPost({ data }) {
+  if (data.isActive) {
+    return (
+      <section aria-labelledby={data.nav.id}>
+        <div className="it-header-slim-wrapper p-0 h-100">
+          <div className="header-pre bg-white border-bottom border-100 w-100 shadow-sm">
+            <div className="container-xxl">
+              <div className="row ">
+                <div className="col-12 g-0">
+                  <div className="header-post-wrapper">
+                    <span id={data.nav.id} className="visually-hidden">
+                      {data.nav.ariaLabel}
+                    </span>
+                    <ul className="list-inline py-4 px-4 px-lg-5 mb-0 d-flex align-items-center flex-nowrap overflow-x-list">
+                      {data.nav.items.map((value, index) => {
+                        if (index + 1 === data.nav.items.length) {
+                          // last on the left side has "me-auto"
+                          styles = "list-item text-nowrap me-5 me-md-auto";
+                        } else {
+                          styles = "list-item text-nowrap me-5";
+                        }
+                        return (
+                          <li key={`banner-item-${index}`} className={styles}>
+                            <Link
+                              to={value.url}
+                              target={value.blank ? "_blank" : undefined}
+                              rel={value.blank ? "noreferrer" : undefined}
+                            >
+                              <Icon {...value.icon} />
+                              {value.title && (
+                                <ReactMarkdown components={{ p: "span" }}>
+                                  {value.title}
+                                </ReactMarkdown>
+                              )}
+                            </Link>
+                          </li>
+                        );
+                      })}
+                      <li
+                        key={`banner-item-${data.nav.items.length}${1}`}
+                        className="list-item text-nowrap ms-5 me-md-0"
+                      >
+                        <Link
+                          className="simple-cta fw-semibold"
+                          to={data.nav.newsletter.url}
+                          target={
+                            data.nav.newsletter.blank ? "_blank" : undefined
+                          }
+                          rel={
+                            data.nav.newsletter.blank ? "noreferrer" : undefined
+                          }
+                        >
+                          <span className="text-end">
+                            {data.nav.newsletter.title}
+                          </span>
+                          <Icon {...iconNewsletter} />
+                        </Link>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
 }
 
-export default HeaderPost
+export default HeaderPost;

--- a/src/components/header-pre/header-pre.js
+++ b/src/components/header-pre/header-pre.js
@@ -1,24 +1,26 @@
 /* eslint-disable react/jsx-no-useless-fragment */
-import React from "react"
-import Link from "../link/link"
+import React from "react";
+import Link from "../link/link";
 
-function HeaderPre({data}) {
+function HeaderPre({ data }) {
   if (typeof window === "undefined") {
-    return <></>
+    return <></>;
   }
 
   return window.location.hostname === data.showOn ? (
     <div className="header-pre bg-white py-2 small">
       <div className="container-xxl">
         <div className="text-center">
-          <span className="fw-semibold">{data.title}</span> -{' '}
+          <span className="fw-semibold">{data.title}</span> -{" "}
           <Link to={`https://designers.italia.it${window.location.pathname}`}>
             {data.link}
           </Link>
         </div>
       </div>
     </div>
-  ) : <></>
+  ) : (
+    <></>
+  );
 }
 
-export default HeaderPre
+export default HeaderPre;

--- a/src/components/header-slim/header-slim.js
+++ b/src/components/header-slim/header-slim.js
@@ -1,36 +1,35 @@
-import React, { useRef, useEffect } from "react"
-import { Collapse } from "bootstrap-italia"
-import Icon from "../icon/icon"
-import List from "../list/list"
-import ListItem from "../list-item/list-item"
-import Dropdown from "../dropdown/dropdown"
-import "./header-slim.scss"
+import React, { useRef, useEffect } from "react";
+import { Collapse } from "bootstrap-italia";
+import Icon from "../icon/icon";
+import List from "../list/list";
+import ListItem from "../list-item/list-item";
+import Dropdown from "../dropdown/dropdown";
+import "./header-slim.scss";
 
 function HeaderSlim({ data }) {
-
-  const collRef = useRef(null)
-  const collObjRef = useRef(null)
+  const collRef = useRef(null);
+  const collObjRef = useRef(null);
 
   const toggleAria = (element) => {
-    const ariaAttr = element.getAttribute('aria-expanded')
-    let newVal = 'true'
-    if (ariaAttr === 'true') {
-      newVal = 'false'
+    const ariaAttr = element.getAttribute("aria-expanded");
+    let newVal = "true";
+    if (ariaAttr === "true") {
+      newVal = "false";
     }
-    element.setAttribute('aria-expanded', newVal)
-  }
+    element.setAttribute("aria-expanded", newVal);
+  };
 
   const collapseToggle = (evt) => {
-    evt.preventDefault()
+    evt.preventDefault();
     if (collObjRef.current) {
-      collObjRef.current.toggle()
-      toggleAria(evt.currentTarget)
+      collObjRef.current.toggle();
+      toggleAria(evt.currentTarget);
     }
-  }
+  };
 
   useEffect(() => {
-    collObjRef.current = new Collapse(collRef.current, { toggle: false })
-  })
+    collObjRef.current = new Collapse(collRef.current, { toggle: false });
+  });
 
   return (
     <div className="it-header-slim-wrapper">
@@ -61,35 +60,67 @@ function HeaderSlim({ data }) {
               </div>
               <div className="nav-mobile">
                 <nav aria-label={data.nav.ariaLabel}>
-                  <div className="d-flex align-items-center" >
+                  <div className="d-flex align-items-center">
                     <div className="navbar-brand d-lg-none">
                       <span>
-                        <a target="_blank" className="p-2" href="https://innovazione.gov.it" rel="noreferrer">DTD</a> + <a target="_blank" className="p-2" href="https://agid.gov.it" rel="noreferrer">AgID</a>
+                        <a
+                          target="_blank"
+                          className="p-2"
+                          href="https://innovazione.gov.it"
+                          rel="noreferrer"
+                        >
+                          DTD
+                        </a>{" "}
+                        +{" "}
+                        <a
+                          target="_blank"
+                          className="p-2"
+                          href="https://agid.gov.it"
+                          rel="noreferrer"
+                        >
+                          AgID
+                        </a>
                       </span>
                     </div>
-                    <a className="it-opener d-lg-none p-2 collapsed" onClick={collapseToggle} href={`#${data.nav.id}`} role="button" aria-expanded="false" aria-controls={data.nav.id} data-focus-mouse="false">
-                      <span className="visually-hidden">Apri/chiudi menu secondario</span>
+                    <a
+                      className="it-opener d-lg-none p-2 collapsed"
+                      onClick={collapseToggle}
+                      href={`#${data.nav.id}`}
+                      role="button"
+                      aria-expanded="false"
+                      aria-controls={data.nav.id}
+                      data-focus-mouse="false"
+                    >
+                      <span className="visually-hidden">
+                        Apri/chiudi menu secondario
+                      </span>
                       <Icon icon="sprites.svg#it-expand" />
                     </a>
                   </div>
                   <List ref={collRef} id={data.nav.id} isMenu collapsable>
                     {data.nav.items.map((value, index) => (
-                        <ListItem key={`list-item-${  index}`} url={value.url} active={value.active}>{value.title}</ListItem>
-                      ))}
+                      <ListItem
+                        key={`list-item-${index}`}
+                        url={value.url}
+                        active={value.active}
+                      >
+                        {value.title}
+                      </ListItem>
+                    ))}
                   </List>
                 </nav>
               </div>
-              {data.langs &&
+              {data.langs && (
                 <div className="it-header-slim-right-zone">
                   <Dropdown {...data.langs} />
                 </div>
-              }
+              )}
             </div>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default HeaderSlim
+export default HeaderSlim;

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -1,32 +1,30 @@
-import React, { useEffect } from "react"
+import React, { useEffect } from "react";
 
-import {HeaderSticky} from "bootstrap-italia"
+import { HeaderSticky } from "bootstrap-italia";
 
-function Header({
-  data,
-  children
-}) {
+function Header({ data, children }) {
   useEffect(() => {
     // eslint-disable-next-line no-new
-    new HeaderSticky(document.getElementById("header"))
-  })
-  const styles = "it-header-wrapper"
-    + `${data.sticky ? ' it-header-sticky' : ''}`
-    + `${data.shadow ? ' shadow' : ''}`
-    + `${data.border ? ' border-bottom border-white' : ''}`
+    new HeaderSticky(document.getElementById("header"));
+  });
+  const styles =
+    "it-header-wrapper" +
+    `${data.sticky ? " it-header-sticky" : ""}` +
+    `${data.shadow ? " shadow" : ""}` +
+    `${data.border ? " border-bottom border-white" : ""}`;
 
   return (
     <header
       className={styles}
       id="header"
-      data-bs-toggle={data.sticky ? 'sticky' : ''}
-      data-bs-position-type={data.sticky ? 'fixed' : ''}
-      data-bs-sticky-class-name={data.sticky ? 'is-sticky' : ''}
+      data-bs-toggle={data.sticky ? "sticky" : ""}
+      data-bs-position-type={data.sticky ? "fixed" : ""}
+      data-bs-sticky-class-name={data.sticky ? "is-sticky" : ""}
       data-bs-target={`#${data.navbar.id}`}
-      >
+    >
       {children}
     </header>
-  )
+  );
 }
 
-export default Header
+export default Header;

--- a/src/components/hero/hero.js
+++ b/src/components/hero/hero.js
@@ -1,13 +1,14 @@
-import * as React from "react"
-import "./hero.scss"
+import classNames from "classnames";
+import * as React from "react";
+import "./hero.scss";
 
-import ReactMarkdown from "react-markdown"
-import ImageResponsive from "../image-responsive/image-responsive"
-import Breadcrumbs from "../breadcrumbs/breadcrumbs"
-import Icon from "../icon/icon"
-import ShareButton from "../share-button/share-button"
-import Tag from "../tag/tag"
-import Kangaroo from "../kangaroo/kangaroo"
+import ReactMarkdown from "react-markdown";
+import ImageResponsive from "../image-responsive/image-responsive";
+import Breadcrumbs from "../breadcrumbs/breadcrumbs";
+import Icon from "../icon/icon";
+import ShareButton from "../share-button/share-button";
+import Tag from "../tag/tag";
+import Kangaroo from "../kangaroo/kangaroo";
 
 function Hero({
   pageContext,
@@ -28,57 +29,69 @@ function Hero({
   alt,
   imgRatio,
   kangaroo,
-  noBorder
+  noBorder,
 }) {
-  const styles = 'hero'
-    + `${background ? ` bg-${  background}` : ''}`
-    + `${column ? ' column-hero' : ''}`
+  const styles =
+    "hero" +
+    `${background ? ` bg-${background}` : ""}` +
+    `${column ? " column-hero" : ""}`;
   // heading level
-  let HLevel
-  let SubtitleLevel
+  let HLevel;
+  let SubtitleLevel;
   if (headingLevel) {
     HLevel = `h${headingLevel}`;
-    SubtitleLevel = `h${headingLevel + 1}`
+    SubtitleLevel = `h${headingLevel + 1}`;
   } else {
-    HLevel = `h1`
-    SubtitleLevel = `p`
+    HLevel = `h1`;
+    SubtitleLevel = `p`;
   }
 
-  const textStyle = "texts py-3"
-    + `${centered ? ' pb-lg-4' : ' pb-lg-5'}`
+  const textStyle = classNames("texts py-3", {
+    "pb-lg-4": centered,
+    "pb-lg-5": !centered,
+  });
 
-  const imgStyle = 'img-wrapper ratio mb-4 mb-lg-3 rounded'
-    + `${imgRatio ? ` ratio-${  imgRatio}` : ''}`
+  const imgStyle = classNames("img-wrapper ratio mb-4 mb-lg-3 rounded", {
+    [`ratio-${imgRatio}`]: imgRatio,
+  });
 
-  const imgResponsiveStyle = 'rounded'
+  const imgResponsiveStyle = "rounded";
 
-  const rowStyle = 'row g-0'
-    + `${centered ? ' justify-content-lg-center' : ''}`
+  const rowStyle = classNames("row g-0", {
+    "justify-content-lg-center": centered,
+  });
 
-  let columnStyle = ' col-12 g-0 px-3' // col-md-10 offset-md-1'
-    + `${centered ? ' col-lg-7 offset-lg-0' : ' ps-lg-5 pe-lg-0 col-lg-7'}`
+  let columnStyle = classNames("col-12 g-0 px-3", {
+    "col-lg-7 offset-lg-0": centered,
+    "ps-lg-5 pe-lg-0 col-lg-7": !centered,
+  });
 
-  const breadcrumbsStyle = 'hero-top px-3 pt-4'
-    + `${column ? ' ' : ' px-lg-5 '}`
+  const breadcrumbsStyle = classNames("hero-top px-3 pt-4", {
+    "px-lg-5": column,
+  });
 
-  const kangarooZoneStyle = 'kangaroo-zone'
-    + `${noBorder ? ' no-border' : ''}`
-    + `${specialKangarooComponent ? ' pb-4 pb-md-5 pb-lg-0' : ''}`
+  const kangarooZoneStyle = classNames("kangaroo-zone", {
+    "no-border": noBorder,
+    "pb-4 pb-md-5 pb-lg-0": specialKangarooComponent,
+  });
 
-  let kangarooColumnStyle = 'col-12 g-0' // col-12 col-md-10 offset-md-1'
-    + `${centered ? ' col-lg-7 offset-lg-0 ' : ''}`
+  let kangarooColumnStyle = classNames("col-12 g-0", {
+    "col-lg-7 offset-lg-0": centered,
+  });
 
-  let rightColumnStyle = "  col-12 col-md-12 col-lg-4 offset-lg-1 d-flex flex-column px-3 pe-lg-5 pt-4"
+  let rightColumnStyle =
+    "col-12 col-md-12 col-lg-4 offset-lg-1 d-flex flex-column px-3 pe-lg-5 pt-4";
 
   if (column) {
-    columnStyle = "px-3 col-12 col-md-8"
-    kangarooColumnStyle = "col-12 g-0"
-    rightColumnStyle = "col-12 col-md-3 offset-md-1 d-flex flex-column px-3 pe-lg-5 pt-md-4"
+    columnStyle = "px-3 col-12 col-md-8";
+    kangarooColumnStyle = "col-12 g-0";
+    rightColumnStyle =
+      "col-12 col-md-3 offset-md-1 d-flex flex-column px-3 pe-lg-5 pt-md-4";
   }
 
-  const shareColor = background === ('primary' || 'dark') ? 'white' : 'primary'
+  const shareColor = background === ("primary" || "dark") ? "white" : "primary";
 
-  const url = pageContext.breadcrumb.location
+  const url = pageContext.breadcrumb.location;
 
   return (
     <div className={styles}>
@@ -89,7 +102,11 @@ function Hero({
             <div className="col-12 g-0">
               <div className={breadcrumbsStyle}>
                 {crumbLabel ? (
-                  <Breadcrumbs pageContext={pageContext} crumbLabel={crumbLabel} title={name} />
+                  <Breadcrumbs
+                    pageContext={pageContext}
+                    crumbLabel={crumbLabel}
+                    title={name}
+                  />
                 ) : (
                   <Breadcrumbs pageContext={pageContext} title={name} />
                 )}
@@ -102,24 +119,33 @@ function Hero({
                         <HLevel className="title">{title}</HLevel>
                         {titleTag && <Tag {...titleTag} />}
                       </div>
-                      <SubtitleLevel className="subtitle fw-normal fs-10">{subtitle}</SubtitleLevel>
+                      <SubtitleLevel className="subtitle fw-normal fs-10">
+                        {subtitle}
+                      </SubtitleLevel>
                       {tag && <Tag {...tag} />}
-                      {pretext &&
+                      {pretext && (
                         <div className="bottom-text">
                           <div className="pre-text">
-                            {pretext.icon && <Icon {...pretext.icon} addonClasses="me-2" />}
-                            <span className="text-uppercase">{pretext.text}</span>
+                            {pretext.icon && (
+                              <Icon {...pretext.icon} addonClasses="me-2" />
+                            )}
+                            <span className="text-uppercase">
+                              {pretext.text}
+                            </span>
                           </div>
                           {text && <ReactMarkdown>{text}</ReactMarkdown>}
                         </div>
-                      }
+                      )}
                     </div>
-                    {centered && <ShareButton title={title} url={url} color={shareColor} />}
-                    {kangaroo && specialKangarooComponent &&
+                    {centered && (
+                      <ShareButton title={title} url={url} color={shareColor} />
+                    )}
+                    {kangaroo && specialKangarooComponent && (
                       <div className="">
                         <div className={kangarooZoneStyle}>
                           <div className="container-xxl">
-                            <div className="row justify-content-lg-center">{/* rowStyle */}
+                            <div className="row justify-content-lg-center">
+                              {/* rowStyle */}
                               <div className={kangarooColumnStyle}>
                                 <Kangaroo {...kangaroo} />
                               </div>
@@ -127,36 +153,43 @@ function Hero({
                           </div>
                         </div>
                       </div>
-                    }
+                    )}
                   </div>
-                  {!centered &&
+                  {!centered && (
                     // <div className="col-12 col-md-10 col-lg-3 offset-md-1 px-4 px-lg-2 d-flex flex-column">
                     <div className={rightColumnStyle}>
-                      {img && <div className={imgStyle}>
-                        <ImageResponsive src={img} alt={alt} imgClassName={imgResponsiveStyle} />
-                      </div>}
+                      {img && (
+                        <div className={imgStyle}>
+                          <ImageResponsive
+                            src={img}
+                            alt={alt}
+                            imgClassName={imgResponsiveStyle}
+                          />
+                        </div>
+                      )}
                       <ShareButton title={title} url={url} color={shareColor} />
                     </div>
-                  }
+                  )}
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      {kangaroo && !specialKangarooComponent &&
+      {kangaroo && !specialKangarooComponent && (
         <div className={kangarooZoneStyle}>
           <div className="container-xxl">
-            <div className="row justify-content-lg-center">{/* rowStyle */}
+            <div className="row justify-content-lg-center">
+              {/* rowStyle */}
               <div className={kangarooColumnStyle}>
                 <Kangaroo {...kangaroo} />
               </div>
             </div>
           </div>
         </div>
-      }
+      )}
     </div>
-  )
+  );
 }
 
-export default Hero
+export default Hero;

--- a/src/components/highlight-cards/highlight-cards.js
+++ b/src/components/highlight-cards/highlight-cards.js
@@ -1,9 +1,10 @@
-import React from "react"
-import Card from "../card/card"
-import Button from "../button/button"
-import Topics from "../topics/topics"
+import classNames from "classnames";
+import React from "react";
+import Card from "../card/card";
+import Button from "../button/button";
+import Topics from "../topics/topics";
 // import ReactMarkdown from "react-markdown"
-import "./highlight-cards.scss"
+import "./highlight-cards.scss";
 
 function HighlightCards({
   id,
@@ -19,88 +20,87 @@ function HighlightCards({
   nopadtop,
   hasCustomCols,
 }) {
+  const styles =
+    "highlight-cards" +
+    `${background ? ` bg-${background}` : ""}` +
+    `${nospace ? "" : "  py-5 py-lg-7"}` +
+    `${nopadtop ? "  no-pad-top" : ""}`;
 
-  const styles = 'highlight-cards'
-	+ `${background ? ` bg-${background}` : ''}`
-  + `${nospace ? '' : '  py-5 py-lg-7'}`
-  + `${nopadtop ? '  no-pad-top' : ''}`
+  let cardStyles = classNames("col-12 col-md-6 mb-3 mb-md-4", {
+    "col-lg-4": !col4,
+    "col-lg-3": col4,
+  });
 
-  let cardStyles = 'col-12 col-md-6 mb-3 mb-md-4'
-	+ `${col4 ? ' col-lg-3' : ' col-lg-4'}`
+  const styleCustomCols = classNames("row pb-4", {
+    "justify-content-center": hasCustomCols,
+  });
 
-  const styleCustomCols = 'row pb-4'
-  + `${hasCustomCols ? ' justify-content-center' : ''}`
-
-  let cardsItems
-  let buttonsItems
+  let cardsItems;
+  let buttonsItems;
 
   // heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h2`
-	}
-
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h2`;
+  }
 
   if (cards) {
-    cardsItems = cards.map((item,index) => {
-      if (!item.customCol){
-        return(
+    cardsItems = cards.map((item, index) => {
+      if (!item.customCol) {
+        return (
           <div className={cardStyles} key={`cardcol-${index}`}>
             <Card {...item} />
           </div>
-        )
+        );
       }
-        cardStyles = `col-12 col-md-6 mb-3 mb-md-4 ${item.customCol}`
-        return(
-          <div className={cardStyles} key={`cardcol-${index}`}>
-            <Card {...item} />
-          </div>
-        )
-
-
-    })
+      cardStyles = `col-12 col-md-6 mb-3 mb-md-4 ${item.customCol}`;
+      return (
+        <div className={cardStyles} key={`cardcol-${index}`}>
+          <Card {...item} />
+        </div>
+      );
+    });
   }
 
   if (buttons) {
-    buttonsItems = buttons.map((item,index) => (
-        <Button {...item} key={`button-${index}`}/>
-      ))
+    buttonsItems = buttons.map((item, index) => (
+      <Button {...item} key={`button-${index}`} />
+    ));
   }
 
   return (
     <section className={styles} aria-labelledby={id}>
       <div className="container-xxl">
-        {
-          title && <div className="row mb-4 mb-md-5 intro">
+        {title && (
+          <div className="row mb-4 mb-md-5 intro">
             <div className="col-12 g-0">
-            {/* <div className='col col-md-10 offset-md-1'> */}
-                <div className="px-3 px-lg-5">
-                  {title && <HLevel id={id} className="mb-2">{title}</HLevel>}
-                  <p className="lead">{text}</p> {/* <ReactMarkdown>{text}</ReactMarkdown> */}
-                </div>
+              {/* <div className='col col-md-10 offset-md-1'> */}
+              <div className="px-3 px-lg-5">
+                {title && (
+                  <HLevel id={id} className="mb-2">
+                    {title}
+                  </HLevel>
+                )}
+                <p className="lead">{text}</p>{" "}
+                {/* <ReactMarkdown>{text}</ReactMarkdown> */}
+              </div>
             </div>
           </div>
-        }
-        {cardsItems &&
-          <div className={styleCustomCols}>
-            {cardsItems}
-          </div>
-        }
-        {topics &&
-          <Topics {...topics}/>
-        }
-        {buttonsItems &&
+        )}
+        {cardsItems && <div className={styleCustomCols}>{cardsItems}</div>}
+        {topics && <Topics {...topics} />}
+        {buttonsItems && (
           <div className="row buttons">
-            <div className='col col-md-10 offset-md-1 justify-content-center d-md-flex'>
+            <div className="col col-md-10 offset-md-1 justify-content-center d-md-flex">
               {buttonsItems}
             </div>
           </div>
-        }
+        )}
       </div>
     </section>
-  )
+  );
 }
 
-export default HighlightCards
+export default HighlightCards;

--- a/src/components/highlight/highlight.js
+++ b/src/components/highlight/highlight.js
@@ -1,99 +1,114 @@
-import * as React from "react"
-import './highlight.scss'
-import ReactMarkdown from "react-markdown"
-import ImageResponsive from "../image-responsive/image-responsive"
-import Button from "../button/button"
-import Icon from "../icon/icon"
-import Numbers from "../numbers/numbers"
+import * as React from "react";
+import "./highlight.scss";
+import ReactMarkdown from "react-markdown";
+import ImageResponsive from "../image-responsive/image-responsive";
+import Button from "../button/button";
+import Icon from "../icon/icon";
+import Numbers from "../numbers/numbers";
 
 function Highlight({
-	id,
-	background,
-	img,
-    alt,
-	icon,
-    overlayImg,
-    overlayAlt,
-	big,
-	title,
-    numbers,
-		headingLevel,
-		subtitle,
-		text,
-		buttons,
-		specular,
-    textSanSerif,
-    fullImg,
-    children,
-    reversedMobile,
-	padBottom
-	}) {
-	const styles = 'highlight'
-	+ `${background ? ` bg-${background}` : ''}`
-	+ `${big ? ' highlight-big' : ''}`
-	+ `${padBottom ? ' mb-5' : ''}`
+  id,
+  background,
+  img,
+  alt,
+  icon,
+  overlayImg,
+  overlayAlt,
+  big,
+  title,
+  numbers,
+  headingLevel,
+  subtitle,
+  text,
+  buttons,
+  specular,
+  textSanSerif,
+  fullImg,
+  children,
+  reversedMobile,
+  padBottom,
+}) {
+  const styles =
+    "highlight" +
+    `${background ? ` bg-${background}` : ""}` +
+    `${big ? " highlight-big" : ""}` +
+    `${padBottom ? " mb-5" : ""}`;
 
-	const classes = 'highlight-content d-lg-flex'
-	+ `${specular ? ' flex-lg-row-reverse' : ''}`
-  + `${reversedMobile ? ' d-flex flex-column-reverse' : ''}`
-  + `${img || overlayImg ? '' : ' no-image'}`
+  const classes =
+    "highlight-content d-lg-flex" +
+    `${specular ? " flex-lg-row-reverse" : ""}` +
+    `${reversedMobile ? " d-flex flex-column-reverse" : ""}` +
+    `${img || overlayImg ? "" : " no-image"}`;
 
-	// heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h3`
-	}
+  // heading level
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h3`;
+  }
 
-	// buttons
-	let ButtonsRender
-	if (buttons) {
-		ButtonsRender = buttons.map((btn,index) => (
-			   <Button key={`h-button-${index}`} {...btn}/>
-			))
-	}
+  // buttons
+  let ButtonsRender;
+  if (buttons) {
+    ButtonsRender = buttons.map((btn, index) => (
+      <Button key={`h-button-${index}`} {...btn} />
+    ));
+  }
 
-  let textClass
+  let textClass;
   if (textSanSerif) {
-    textClass = "h-text"
-  }else{
-    textClass = "h-text font-serif"
+    textClass = "h-text";
+  } else {
+    textClass = "h-text font-serif";
   }
 
-  let ratioClass
+  let ratioClass;
   if (fullImg) {
-    ratioClass = "img-container full"
-  }else{
-    ratioClass = "img-container ratio ratio-16x9"
+    ratioClass = "img-container full";
+  } else {
+    ratioClass = "img-container ratio ratio-16x9";
   }
 
-
-	return (
-		<section className={styles} aria-labelledby={id}>
-			<div className="container-xxl">
-				<div className="row">
-					<div className="col-12 g-0">
-						<div className={classes}>
-							<div className={ratioClass}>
-								{img &&<ImageResponsive className="main-image" src={img} alt={alt}/> }
-								{icon && <Icon {...icon}/>}
-                				{overlayImg && <ImageResponsive src={overlayImg} alt={overlayAlt} className="overlay-image"/>}
-							</div>
-							<div className="text-container px-3 py-5 px-lg-5 py-lg-6">
-								<HLevel id={id}>{title}</HLevel>
-								{subtitle && <p className="lead mb-4">{subtitle}</p>}
-              					{numbers && <Numbers {...numbers}/>}
-								{text && <div className={textClass}><ReactMarkdown>{text}</ReactMarkdown></div>}
-								{ButtonsRender && <div className="buttons-wrapper mt-5">{ButtonsRender}</div>}
-               					{ children }
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</section>
-	)
+  return (
+    <section className={styles} aria-labelledby={id}>
+      <div className="container-xxl">
+        <div className="row">
+          <div className="col-12 g-0">
+            <div className={classes}>
+              <div className={ratioClass}>
+                {img && (
+                  <ImageResponsive className="main-image" src={img} alt={alt} />
+                )}
+                {icon && <Icon {...icon} />}
+                {overlayImg && (
+                  <ImageResponsive
+                    src={overlayImg}
+                    alt={overlayAlt}
+                    className="overlay-image"
+                  />
+                )}
+              </div>
+              <div className="text-container px-3 py-5 px-lg-5 py-lg-6">
+                <HLevel id={id}>{title}</HLevel>
+                {subtitle && <p className="lead mb-4">{subtitle}</p>}
+                {numbers && <Numbers {...numbers} />}
+                {text && (
+                  <div className={textClass}>
+                    <ReactMarkdown>{text}</ReactMarkdown>
+                  </div>
+                )}
+                {ButtonsRender && (
+                  <div className="buttons-wrapper mt-5">{ButtonsRender}</div>
+                )}
+                {children}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }
 
-export default Highlight
+export default Highlight;

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -1,30 +1,35 @@
-import * as React from "react"
+import * as React from "react";
 
 function Icon({
-	icon,     // url of icon 'sprites.svg#it-tool'
-	size,     // xs, sm, lg xl
-	padded,   // true, no prop
-	bg,       // light, dark
-	align,    // bottom,middle,top
-	color,    // primary,secondary,success,warning,danger,light,white
-	hidden,
-	addonClasses,
-  ariaLabel
-
+  icon, // url of icon 'sprites.svg#it-tool'
+  size, // xs, sm, lg xl
+  padded, // true, no prop
+  bg, // light, dark
+  align, // bottom,middle,top
+  color, // primary,secondary,success,warning,danger,light,white
+  hidden,
+  addonClasses,
+  ariaLabel,
 }) {
-	const styles = 'icon'
-		+ `${padded ? ' icon-padded' : ''}`
-		+ `${size ? ` icon-${size}` : ''}`
-		+ `${bg ? ` bg-${bg}` : ''}`
-		+ `${align ? ` align-${align}` : ''}`
-		+ `${color ? ` icon-${color}` : ''}`
-		+ `${addonClasses ? ` ${addonClasses}` : ''}`
+  const styles =
+    "icon" +
+    `${padded ? " icon-padded" : ""}` +
+    `${size ? ` icon-${size}` : ""}` +
+    `${bg ? ` bg-${bg}` : ""}` +
+    `${align ? ` align-${align}` : ""}` +
+    `${color ? ` icon-${color}` : ""}` +
+    `${addonClasses ? ` ${addonClasses}` : ""}`;
 
-	return(
-		<svg role="img" className={styles} aria-hidden={hidden} aria-label={ariaLabel}>
-			<use href={`/svg/${icon}`} />
-		</svg>
-	)
+  return (
+    <svg
+      role="img"
+      className={styles}
+      aria-hidden={hidden}
+      aria-label={ariaLabel}
+    >
+      <use href={`/svg/${icon}`} />
+    </svg>
+  );
 }
 
-export default Icon
+export default Icon;

--- a/src/components/image-icons/image-icons.js
+++ b/src/components/image-icons/image-icons.js
@@ -1,62 +1,56 @@
-import React from "react"
-import ImageResponsive from "../image-responsive/image-responsive"
-import Icon from "../icon/icon"
-import "./image-icons.scss"
+import React from "react";
+import ImageResponsive from "../image-responsive/image-responsive";
+import Icon from "../icon/icon";
+import "./image-icons.scss";
 
-function ImageIcons({
-  image,
-  alt,
-  icons,
-  images,
-  background,
-  customStyle
-}) {
+function ImageIcons({ image, alt, icons, images, background, customStyle }) {
+  const styles =
+    "image-icons" +
+    `${background ? ` bg-${background}` : ""}` +
+    `${customStyle ? ` ${customStyle}` : ""}`;
 
-  const styles = 'image-icons'
-	+ `${background ? ` bg-${background}` : ''}`
-  + `${customStyle ? ` ${customStyle}` : ''}`
-
-  let iconItems
-  let imagesItems
+  let iconItems;
+  let imagesItems;
 
   if (icons) {
-    iconItems = icons.map((item,index) => {
+    iconItems = icons.map((item, index) => {
       // FIXME
       // eslint-disable-next-line no-param-reassign
-      item.icon.addonClasses = "flex-shrink-0"
+      item.icon.addonClasses = "flex-shrink-0";
       // eslint-disable-next-line no-param-reassign
-      item.icon.hidden = true
-      return(
-        <Icon {...item.icon} key={`icons-${index}`}/>
-      )
-    })
+      item.icon.hidden = true;
+      return <Icon {...item.icon} key={`icons-${index}`} />;
+    });
   }
 
   if (images) {
-    imagesItems = images.map((item,index) => (
-        <ImageResponsive src={item.img} alt={item.alt} key={`image-${index}`}/>
-      ))
+    imagesItems = images.map((item, index) => (
+      <ImageResponsive src={item.img} alt={item.alt} key={`image-${index}`} />
+    ));
   }
-
 
   return (
     <div className={styles}>
       <div className="container-xxl">
         <div className="row position-relative">
           <div className="col g-0">
-            <ImageResponsive src={image} alt={alt} className="w-100" imgClassName="img-fluid w-100"/>
+            <ImageResponsive
+              src={image}
+              alt={alt}
+              className="w-100"
+              imgClassName="img-fluid w-100"
+            />
           </div>
           {(iconItems || imagesItems) && (
-              <div className="icons position-absolute top-0 start-50 translate-middle-x h-100 d-flex align-items-center justify-content-between">
-                  {iconItems}
-                  {imagesItems}
-              </div>
-            )
-          }
+            <div className="icons position-absolute top-0 start-50 translate-middle-x h-100 d-flex align-items-center justify-content-between">
+              {iconItems}
+              {imagesItems}
+            </div>
+          )}
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default ImageIcons
+export default ImageIcons;

--- a/src/components/image-responsive/image-responsive.js
+++ b/src/components/image-responsive/image-responsive.js
@@ -1,10 +1,10 @@
-import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
-import { GatsbyImage } from "gatsby-plugin-image"
-import "./image-responsive.scss"
+import React from "react";
+import { useStaticQuery, graphql } from "gatsby";
+import { GatsbyImage } from "gatsby-plugin-image";
+import "./image-responsive.scss";
 
 function ImageResponsive(props) {
-  const { src, alt, imgClassName, loading, ...otherProps } = props
+  const { src, alt, imgClassName, loading, ...otherProps } = props;
 
   const data = useStaticQuery(graphql`
     query ImageResponsiveQuery {
@@ -29,21 +29,45 @@ function ImageResponsive(props) {
         }
       }
     }
-  `)
+  `);
 
-  const imageRemoteFound = data ? data.allRemoteAsset.nodes.find((asset) => asset.source === src) : null
-  const imageFound = data ? data.allFile.nodes.find((asset) => asset.absolutePath.endsWith(src)) : null
+  const imageRemoteFound = data
+    ? data.allRemoteAsset.nodes.find((asset) => asset.source === src)
+    : null;
+  const imageFound = data
+    ? data.allFile.nodes.find((asset) => asset.absolutePath.endsWith(src))
+    : null;
 
+  const gatsbyImageData =
+    // eslint-disable-next-line no-nested-ternary
+    imageRemoteFound && imageRemoteFound.file.childImageSharp
+      ? imageRemoteFound.file.childImageSharp.gatsbyImageData
+      : imageFound && imageFound.childImageSharp
+      ? imageFound.childImageSharp.gatsbyImageData
+      : null;
   // eslint-disable-next-line no-nested-ternary
-  const gatsbyImageData = imageRemoteFound && imageRemoteFound.file.childImageSharp ? imageRemoteFound.file.childImageSharp.gatsbyImageData : imageFound && imageFound.childImageSharp ? imageFound.childImageSharp.gatsbyImageData : null
-  // eslint-disable-next-line no-nested-ternary
-  const realSrc = imageRemoteFound ? imageRemoteFound.file.publicURL : imageFound ? imageFound.publicURL : src
+  const realSrc = imageRemoteFound
+    ? imageRemoteFound.file.publicURL
+    : imageFound
+    ? imageFound.publicURL
+    : src;
 
-  return (
-    gatsbyImageData
-      ? <GatsbyImage image={gatsbyImageData} alt={ alt || '' } imgClassName={imgClassName} loading={loading || 'lazy'} {...otherProps} />
-      : <img src={realSrc} alt={alt || ''}  className={imgClassName} {...otherProps} />
-  )
+  return gatsbyImageData ? (
+    <GatsbyImage
+      image={gatsbyImageData}
+      alt={alt || ""}
+      imgClassName={imgClassName}
+      loading={loading || "lazy"}
+      {...otherProps}
+    />
+  ) : (
+    <img
+      src={realSrc}
+      alt={alt || ""}
+      className={imgClassName}
+      {...otherProps}
+    />
+  );
 }
 
-export default ImageResponsive
+export default ImageResponsive;

--- a/src/components/img-full/img-full.js
+++ b/src/components/img-full/img-full.js
@@ -1,16 +1,13 @@
-import React from "react"
-import ImageResponsive from "../image-responsive/image-responsive"
-import "./img-full.scss"
+import React from "react";
+import ImageResponsive from "../image-responsive/image-responsive";
+import "./img-full.scss";
 
-function ImgFull({
-  img,
-  alt
-}) {
-  return(
+function ImgFull({ img, alt }) {
+  return (
     <div className="img-full mb-5">
-      <ImageResponsive imgClassName="w-100 img-fluid" src={img} alt={alt}/>
+      <ImageResponsive imgClassName="w-100 img-fluid" src={img} alt={alt} />
     </div>
-  )
+  );
 }
 
-export default ImgFull
+export default ImgFull;

--- a/src/components/interest-aside/interest-aside.js
+++ b/src/components/interest-aside/interest-aside.js
@@ -11,7 +11,7 @@ function InterestAside() {
         </div>
       </div>
     </aside>
-  )
+  );
 }
 
-export default InterestAside
+export default InterestAside;

--- a/src/components/kangaroo/kangaroo.js
+++ b/src/components/kangaroo/kangaroo.js
@@ -1,9 +1,10 @@
-import * as React from "react"
-import "./kangaroo.scss"
-import Icon from "../icon/icon"
-import Chip from "../chip/chip"
-import Dropdown from "../dropdown/dropdown"
-import NavPosition from "../nav-position/nav-position"
+import classNames from "classnames";
+import * as React from "react";
+import "./kangaroo.scss";
+import Icon from "../icon/icon";
+import Chip from "../chip/chip";
+import Dropdown from "../dropdown/dropdown";
+import NavPosition from "../nav-position/nav-position";
 
 function Kangaroo({
   id,
@@ -21,77 +22,94 @@ function Kangaroo({
   noPadding,
   eventInfo,
 }) {
+  const styles = classNames("kangaroo px-3", { "px-lg-5": !noPadding });
+  const colorStyle = classNames({ [`text-${color}`]: color });
 
-  const styles = "kangaroo px-3"
-    + `${noPadding ? ' ' : ' px-lg-5'}`
-
-  const colorStyle = `${color ? ` text-${  color}` : ''}`
-
-  const tagsLabelStyle = `text-uppercase small ${  colorStyle}`
+  const tagsLabelStyle = classNames("text-uppercase small", colorStyle);
 
   return (
     <section className={styles} aria-labelledby={id}>
-      {titleSr && <h2 className="visually-hidden" id={id}>{titleSr}</h2>}
+      {titleSr && (
+        <h2 className="visually-hidden" id={id}>
+          {titleSr}
+        </h2>
+      )}
       <div className="kangaroo-wrapper py-4 d-lg-flex justify-content-between align-items-top">
         <div className="left-zone">
-            {navposition &&
-              <div className="navposition-wrapper">
-                <NavPosition {...navposition} />
-              </div>
-            }
-            {personalInfo &&
-              <div className="personal-info-wrapper">
-                <NavPosition {...personalInfo} />
-              </div>
-            }
-            {eventInfo &&
-              <div className="event-info-wrapper">
-                <NavPosition {...eventInfo} />
-              </div>
-            }
-            {otherInfo &&
-              <div className="other-info-wrapper">
-                <NavPosition {...otherInfo} />
-              </div>
-            }
-          {(tagsLabel && tags) && (tags.length > 0) &&
+          {navposition && (
+            <div className="navposition-wrapper">
+              <NavPosition {...navposition} />
+            </div>
+          )}
+          {personalInfo && (
+            <div className="personal-info-wrapper">
+              <NavPosition {...personalInfo} />
+            </div>
+          )}
+          {eventInfo && (
+            <div className="event-info-wrapper">
+              <NavPosition {...eventInfo} />
+            </div>
+          )}
+          {otherInfo && (
+            <div className="other-info-wrapper">
+              <NavPosition {...otherInfo} />
+            </div>
+          )}
+          {tagsLabel && tags && tags.length > 0 && (
             <div className="pills-wrapper d-md-flex align-items-start pt-3 pt-md-2">
               <div className="d-flex title-wrapper align-items-center mb-2 mb-lg-0 text-uppercase flex-shrink-0">
                 <Icon {...icon} addonClasses="me-3" />
-                <span className={tagsLabelStyle}><strong>{tagsLabel}</strong></span>
+                <span className={tagsLabelStyle}>
+                  <strong>{tagsLabel}</strong>
+                </span>
               </div>
               <div className="chips ms-md-3 mb-2 mb-lg-0">
                 {tags.map((tag, index) => (
-                    <Chip key={`chip-${  index}`} label={tag} size="lg" color="primary" />
-                  ))}
+                  <Chip
+                    key={`chip-${index}`}
+                    label={tag}
+                    size="lg"
+                    color="primary"
+                  />
+                ))}
               </div>
             </div>
-          }
-          {(tagsDesignSystemLabel && tagsDesignSystem) && (tagsDesignSystem.length > 0) &&
-            <div className="pills-wrapper d-md-flex align-items-start">
-              <div className="d-flex title-wrapper align-items-center mb-2 mb-lg-0 text-uppercase flex-shrink-0">
-                <Icon {...icon} addonClasses="me-3" />
-                <span className={tagsLabelStyle}><strong>{tagsDesignSystemLabel}</strong></span>
-              </div>
-              <div className="chips ms-md-3 mb-2 mb-lg-0">
-                {tagsDesignSystem.map((tag, index) => (
-                    <Chip key={`chip-${  index}`} label={tag} size="lg" color="primary" path="design-system/componenti/utili-per" />
+          )}
+          {tagsDesignSystemLabel &&
+            tagsDesignSystem &&
+            tagsDesignSystem.length > 0 && (
+              <div className="pills-wrapper d-md-flex align-items-start">
+                <div className="d-flex title-wrapper align-items-center mb-2 mb-lg-0 text-uppercase flex-shrink-0">
+                  <Icon {...icon} addonClasses="me-3" />
+                  <span className={tagsLabelStyle}>
+                    <strong>{tagsDesignSystemLabel}</strong>
+                  </span>
+                </div>
+                <div className="chips ms-md-3 mb-2 mb-lg-0">
+                  {tagsDesignSystem.map((tag, index) => (
+                    <Chip
+                      key={`chip-${index}`}
+                      label={tag}
+                      size="lg"
+                      color="primary"
+                      path="design-system/componenti/utili-per"
+                    />
                   ))}
+                </div>
               </div>
-            </div>
-          }
-
+            )}
         </div>
-        {dropdown &&
+        {dropdown && (
           <div className="right-zone col-12 col-lg-4 d-flex flex-lg-row-reverse pt-3 pb-4">
             <div className="dropdwon-zone mt-4 mt-lg-0">
               <Dropdown {...dropdown} />
             </div>
           </div>
-        }
+        )}
       </div>
     </section>
-  )
+  );
 }
 
-export default Kangaroo
+export default Kangaroo;

--- a/src/components/label-textarea/label-text-area.js
+++ b/src/components/label-textarea/label-text-area.js
@@ -1,41 +1,35 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useState } from "react";
 
-import { Input } from "bootstrap-italia"
+import { Input } from "bootstrap-italia";
 
 function LabelTextArea(props) {
-    const {
-        id,
-        value,
-        onChange,
-        label = "",
-        ...opts
-    } = props;
-    const [message, setMessage] = useState(value);
-    const handleChange = event => {
-        setMessage(event.target.value);
-        if (typeof onChange === "function") {
-            onChange({
-                value: event.target.value
-            });
-        }
-    };
-    useEffect(() => {
-        // eslint-disable-next-line no-new
-        new Input(document.getElementById(id))
-    });
-    return (
-        <>
-            <label htmlFor={id}>{label}</label>
-            <textarea
-                id={id}
-                className="form-control"
-                onChange={handleChange}
-                {...opts}
-            >
-              {message}
-            </textarea>
-        </>
-    )
+  const { id, value, onChange, label = "", ...opts } = props;
+  const [message, setMessage] = useState(value);
+  const handleChange = (event) => {
+    setMessage(event.target.value);
+    if (typeof onChange === "function") {
+      onChange({
+        value: event.target.value,
+      });
+    }
+  };
+  useEffect(() => {
+    // eslint-disable-next-line no-new
+    new Input(document.getElementById(id));
+  });
+  return (
+    <>
+      <label htmlFor={id}>{label}</label>
+      <textarea
+        id={id}
+        className="form-control"
+        onChange={handleChange}
+        {...opts}
+      >
+        {message}
+      </textarea>
+    </>
+  );
 }
 
-export default LabelTextArea
+export default LabelTextArea;

--- a/src/components/labelinput/labelinput.js
+++ b/src/components/labelinput/labelinput.js
@@ -1,39 +1,34 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useState } from "react";
 
-import { Input } from "bootstrap-italia"
+import { Input } from "bootstrap-italia";
 
 function LabelInput(props) {
-    const {
-        id,
-        value,
-        onChange,
-        label = ""
-    } = props;
-    const [message, setMessage] = useState(value);
-    const handleChange = event => {
-        setMessage(event.target.value);
-        if (typeof onChange === "function") {
-            onChange({
-                value: event.target.value
-            });
-        }
-    };
-    useEffect(() => {
-        // eslint-disable-next-line no-new
-        new Input(document.getElementById(id))
-    });
-    return (
-        <div className="form-group">
-            <label htmlFor={id}>{label}</label>
-            <input
-                type="text"
-                id={id}
-                value={message}
-                className="form-control"
-                onChange={handleChange}
-            />
-        </div>
-    )
+  const { id, value, onChange, label = "" } = props;
+  const [message, setMessage] = useState(value);
+  const handleChange = (event) => {
+    setMessage(event.target.value);
+    if (typeof onChange === "function") {
+      onChange({
+        value: event.target.value,
+      });
+    }
+  };
+  useEffect(() => {
+    // eslint-disable-next-line no-new
+    new Input(document.getElementById(id));
+  });
+  return (
+    <div className="form-group">
+      <label htmlFor={id}>{label}</label>
+      <input
+        type="text"
+        id={id}
+        value={message}
+        className="form-control"
+        onChange={handleChange}
+      />
+    </div>
+  );
 }
 
-export default LabelInput
+export default LabelInput;

--- a/src/components/last-update/last-update.js
+++ b/src/components/last-update/last-update.js
@@ -1,54 +1,49 @@
-import React from "react"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import "./last-update.scss"
+import classNames from "classnames";
+import React from "react";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import "./last-update.scss";
 
-function LastUpdate({
-  pathname,
-  lastModified,
-  noPadding
-}) {
-  let editGithubUrl = `https://github.com/italia/designers.italia.it/tree/main/src/data/content/`
+function LastUpdate({ pathname, lastModified, noPadding }) {
+  let editGithubUrl = `https://github.com/italia/designers.italia.it/tree/main/src/data/content/`;
   if (pathname) {
-    const filePath = pathname === '/'
-      ? "index"
-      : pathname.slice(1).replace(/^\/|\/$/g, '')
+    const filePath =
+      pathname === "/" ? "index" : pathname.slice(1).replace(/^\/|\/$/g, "");
 
-    editGithubUrl += `${filePath}.yaml`
+    editGithubUrl += `${filePath}.yaml`;
   }
 
-  const columnStyle = 'col-12 g-0'
+  const columnStyle = "col-12 g-0";
 
-  const paddingStyle = 'px-3'
-   + `${noPadding ? '' : ' px-lg-5'}`
+  const paddingStyle = classNames("px-3", { "px-lg-5": !noPadding });
 
   return (
     <div className="last-update py-5 py-lg-7">
       <div className="container-xxl">
         <div className="row">
           <div className={columnStyle}>
-            <div className ={paddingStyle}>
+            <div className={paddingStyle}>
               <p>
                 <small>
                   <span>Ultimo aggiornamento: </span>
-                  <time
-                    dateTime={lastModified}
-                    title={lastModified}
-                  >
-                    {new Date(lastModified).toLocaleDateString(
-                      'it-IT',
-                      { year: 'numeric', month: 'long', day: 'numeric' }
-                    )}
+                  <time dateTime={lastModified} title={lastModified}>
+                    {new Date(lastModified).toLocaleDateString("it-IT", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
                   </time>
                   <Link
                     to="https://creativecommons.org/licenses/by-sa/4.0/deed.it"
                     target="_blank"
-                    rel='noreferrer'
+                    rel="noreferrer"
                     className="d-block d-md-inline-block text-decoration-none mt-2 mt-md-0 ms-md-5"
                   >
                     <strong className="d-inline-block me-2">
                       Licenza CC BY-SA 4.0
-                      <span className="visually-hidden">(si apre in una nuova finestra)</span>
+                      <span className="visually-hidden">
+                        (si apre in una nuova finestra)
+                      </span>
                       <Icon
                         icon="sprites.svg#it-external-link"
                         size="md"
@@ -69,7 +64,9 @@ function LastUpdate({
                   >
                     <strong className="d-inline-block me-2">
                       Proponi una modifica a questa pagina
-                      <span className="visually-hidden">(si apre in una nuova finestra)</span>
+                      <span className="visually-hidden">
+                        (si apre in una nuova finestra)
+                      </span>
                     </strong>
                     <Icon
                       icon="sprites.svg#it-pencil"
@@ -83,8 +80,8 @@ function LastUpdate({
           </div>
         </div>
       </div>
-  </div>
-  )
+    </div>
+  );
 }
 
-export default LastUpdate
+export default LastUpdate;

--- a/src/components/link-custom/link-custom.js
+++ b/src/components/link-custom/link-custom.js
@@ -1,8 +1,9 @@
-import React from "react"
-import ImageResponsive from "../image-responsive/image-responsive"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import "./link-custom.scss"
+import classNames from "classnames";
+import React from "react";
+import ImageResponsive from "../image-responsive/image-responsive";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import "./link-custom.scss";
 
 function LinkCustom({
   label,
@@ -12,24 +13,34 @@ function LinkCustom({
   imageClass,
   blank,
   specular,
-  icon
+  icon,
 }) {
-  const linkStyles = "link-custom d-inline-flex align-items-center text-decoration-none"
-    + `${specular ? ' flex-row-reverse text-end' : ''}`
-  const imageStyles = "flex-shrink-0"
-    + `${imageClass ? ` ${imageClass}` : ''}`
+  const linkStyles = classNames(
+    "link-custom d-inline-flex align-items-center text-decoration-none",
+    { "flex-row-reverse text-end": specular },
+  );
+  const imageStyles = classNames("flex-shrink-0", imageClass);
+
   return (
     <Link
       className={linkStyles}
       to={url}
       target={blank ? "_blank" : undefined}
-      rel={blank ? 'noreferrer' : undefined}
+      rel={blank ? "noreferrer" : undefined}
     >
-      {icon ? <Icon {...icon}/> : ''}
-      {image ? <ImageResponsive src={image} aria-hidden="true" imgClassName={imageStyles}/> : ''}
-      <strong className={labelSmall ? 'small' : null}>{label}</strong>
+      {icon ? <Icon {...icon} /> : ""}
+      {image ? (
+        <ImageResponsive
+          src={image}
+          aria-hidden="true"
+          imgClassName={imageStyles}
+        />
+      ) : (
+        ""
+      )}
+      <strong className={labelSmall ? "small" : null}>{label}</strong>
     </Link>
-  )
+  );
 }
 
-export default LinkCustom
+export default LinkCustom;

--- a/src/components/link/link.js
+++ b/src/components/link/link.js
@@ -1,5 +1,5 @@
-import React from "react"
-import { Link as GatsbyLink } from "gatsby"
+import React from "react";
+import { Link as GatsbyLink } from "gatsby";
 
 // Since DOM elements <a> cannot receive activeClassName
 // and partiallyActive, destructure the prop here and
@@ -9,9 +9,9 @@ function Link({ children, to, activeClassName, partiallyActive, ...other }) {
   // This example assumes that any internal link (intended for Gatsby)
   // will start with exactly one slash, and that anything else is external.
   // const internal = /^\/(?!\/)/.test(to) <--- from example
-  const external = /^http/.test(to)
-  const anchor = /#[^\s,]+/.test(to)
-  const file = /\.[0-9a-z]+$/i.test(to)
+  const external = /^http/.test(to);
+  const anchor = /#[^\s,]+/.test(to);
+  const file = /\.[0-9a-z]+$/i.test(to);
 
   // Use Gatsby Link for internal links, and <a> for others
   if (external || anchor || file) {
@@ -19,7 +19,7 @@ function Link({ children, to, activeClassName, partiallyActive, ...other }) {
       <a href={to} {...other}>
         {children}
       </a>
-    )
+    );
   }
   return (
     <GatsbyLink
@@ -30,7 +30,7 @@ function Link({ children, to, activeClassName, partiallyActive, ...other }) {
     >
       {children}
     </GatsbyLink>
-  )
+  );
 }
 
-export default Link
+export default Link;

--- a/src/components/list-archive-all-tags/list-archive-all-tags.js
+++ b/src/components/list-archive-all-tags/list-archive-all-tags.js
@@ -1,18 +1,14 @@
-import * as React from "react"
+import * as React from "react";
 
-import "../../scss/styles.scss"
-import "../../js/globals"
+import "../../scss/styles.scss";
+import "../../js/globals";
 
-import { useStaticQuery, graphql } from "gatsby"
-import classNames from "classnames"
-import ListItem from "../list-item/list-item"
-import Chip from "../chip/chip"
+import { useStaticQuery, graphql } from "gatsby";
+import classNames from "classnames";
+import ListItem from "../list-item/list-item";
+import Chip from "../chip/chip";
 
-function ListArchiveAllTags({
-  background,
-  noSpace,
-}) {
-
+function ListArchiveAllTags({ background, noSpace }) {
   const data = useStaticQuery(graphql`
     query {
       tags: allContent {
@@ -22,29 +18,34 @@ function ListArchiveAllTags({
         }
       }
     }
-  `)
+  `);
 
-  const styles = classNames(
-    'section-editorial',
-  {
+  const styles = classNames("section-editorial", {
     [`bg-${background}`]: background,
-    'py-0': noSpace,
-    'text-white': (background === "dark")
-  })
+    "py-0": noSpace,
+    "text-white": background === "dark",
+  });
 
   return (
     <section className={styles} aria-describedby="archive-list-title">
       <div className="container-xxl">
         <div className="row">
           <div className="col-12 g-0">
-          <div className="px-3 px-lg-0 px-lg-5">
-              <h2 className="border-bottom pb-4" id="archive-list-title">Esplora gli argomenti</h2>
+            <div className="px-3 px-lg-0 px-lg-5">
+              <h2 className="border-bottom pb-4" id="archive-list-title">
+                Esplora gli argomenti
+              </h2>
               <div className="chips-list-wrapper">
                 <ul className="chips-list chips mt-4 mt-md-3 d-flex flex-wrap">
-                  {data.tags.group.map(tag => (
-                    <ListItem key={tag.fieldValue} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
+                  {data.tags.group.map((tag) => (
+                    <ListItem
+                      key={tag.fieldValue}
+                      addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+                    >
                       <Chip label={tag.fieldValue} size="lg" color="primary">
-                        <span className="ms-2 badge neutral-2-bg text-secondary my-0 pb-1">{tag.totalCount}</span>
+                        <span className="ms-2 badge neutral-2-bg text-secondary my-0 pb-1">
+                          {tag.totalCount}
+                        </span>
                       </Chip>
                     </ListItem>
                   ))}
@@ -54,8 +55,8 @@ function ListArchiveAllTags({
           </div>
         </div>
       </div>
-    </section >
-  )
+    </section>
+  );
 }
 
-export default ListArchiveAllTags
+export default ListArchiveAllTags;

--- a/src/components/list-archive-ds-tags/list-archive-ds-tags.js
+++ b/src/components/list-archive-ds-tags/list-archive-ds-tags.js
@@ -1,43 +1,58 @@
-import * as React from "react"
+import * as React from "react";
 
-import "../../scss/styles.scss"
-import "../../js/globals"
+import "../../scss/styles.scss";
+import "../../js/globals";
 
-import { useStaticQuery, graphql } from "gatsby"
-import ListItem from "../list-item/list-item"
-import Chip from "../chip/chip"
+import { useStaticQuery, graphql } from "gatsby";
+import ListItem from "../list-item/list-item";
+import Chip from "../chip/chip";
 
 function ListArchiveDSTags() {
-
   const data = useStaticQuery(graphql`
     query {
       tagsDesignSystem: allContent {
-        group(field: { components: { hero: { kangaroo: { tagsDesignSystem: SELECT } } } }) {
+        group(
+          field: {
+            components: { hero: { kangaroo: { tagsDesignSystem: SELECT } } }
+          }
+        ) {
           fieldValue
           totalCount
         }
       }
     }
-  `)
+  `);
 
   return (
     <section className="pb-5" aria-describedby="archive-list-title">
       <div className="px-0 px-md-3 px-lg-4 px-xl-5 d-md-flex flex-row align-items-center">
-        <h3 className="border-end pe-4" id="archive-list-title">Esplora per utilizzo</h3>
+        <h3 className="border-end pe-4" id="archive-list-title">
+          Esplora per utilizzo
+        </h3>
         <div className="chips-list-wrapper ps-md-4">
           <ul className="chips-list chips mt-4 mt-md-3 d-flex flex-wrap">
-            {data.tagsDesignSystem.group.map(tag => (
-              <ListItem key={tag.fieldValue} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
-                <Chip label={tag.fieldValue} size="lg" color="primary" path="design-system/componenti/utili-per">
-                  <span className="ms-2 badge neutral-2-bg text-secondary my-0 pb-1">{tag.totalCount}</span>
+            {data.tagsDesignSystem.group.map((tag) => (
+              <ListItem
+                key={tag.fieldValue}
+                addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+              >
+                <Chip
+                  label={tag.fieldValue}
+                  size="lg"
+                  color="primary"
+                  path="design-system/componenti/utili-per"
+                >
+                  <span className="ms-2 badge neutral-2-bg text-secondary my-0 pb-1">
+                    {tag.totalCount}
+                  </span>
                 </Chip>
               </ListItem>
             ))}
           </ul>
         </div>
       </div>
-    </section >
-  )
+    </section>
+  );
 }
 
-export default ListArchiveDSTags
+export default ListArchiveDSTags;

--- a/src/components/list-archive-events/list-archive-events.js
+++ b/src/components/list-archive-events/list-archive-events.js
@@ -1,22 +1,18 @@
-import * as React from "react"
+import * as React from "react";
 
-import "../../scss/styles.scss"
-import "../../js/globals"
+import "../../scss/styles.scss";
+import "../../js/globals";
 
-import { useStaticQuery, graphql } from "gatsby"
-import classNames from "classnames"
-import ListItem from "../list-item/list-item"
-import Tag from "../tag/tag"
+import { useStaticQuery, graphql } from "gatsby";
+import classNames from "classnames";
+import ListItem from "../list-item/list-item";
+import Tag from "../tag/tag";
 
-function ListArchiveEvents({
-  background,
-  noSpace,
-}) {
-
+function ListArchiveEvents({ background, noSpace }) {
   const data = useStaticQuery(graphql`
     query {
       allContent(
-        filter: {metadata: {archive: {in: "eventi"}}}
+        filter: { metadata: { archive: { in: "eventi" } } }
         sort: { seo: { pathname: DESC } }
       ) {
         totalCount
@@ -52,25 +48,23 @@ function ListArchiveEvents({
         }
       }
     }
-  `)
+  `);
 
-  const { edges } = data.allContent
-  const tagHeader = 'Esplora l’archivio'
+  const { edges } = data.allContent;
+  const tagHeader = "Esplora l’archivio";
 
   const iconOpt = {
-    icon: 'sprites.svg#it-calendar',
-    size: 'sm',
+    icon: "sprites.svg#it-calendar",
+    size: "sm",
     color: "primary",
-    addonClasses: 'mt-1 flex-shrink-0 me-1 me-md-3'
-  }
+    addonClasses: "mt-1 flex-shrink-0 me-1 me-md-3",
+  };
 
-  const styles = classNames(
-    'section-editorial',
-  {
+  const styles = classNames("section-editorial", {
     [`bg-${background}`]: background,
-    'py-0': noSpace,
-    'text-white': (background === "dark")
-  })
+    "py-0": noSpace,
+    "text-white": background === "dark",
+  });
 
   return (
     <section className={styles} aria-describedby="archive-list-title">
@@ -78,43 +72,67 @@ function ListArchiveEvents({
         <div className="row">
           <div className="col-12 g-0">
             <div className="px-3 px-lg-0 px-lg-5">
-              <h2 className="border-bottom pb-4" id="archive-list-title">{tagHeader}</h2>
+              <h2 className="border-bottom pb-4" id="archive-list-title">
+                {tagHeader}
+              </h2>
               <div className="it-list-wrapper">
                 <ul className="it-list mt-4 mt-md-3">
                   {edges.map(({ node }) => {
-                    const { id } = node
-                    const { pathname } = node.seo
-                    const title = node.components?.hero?.title
-                    const { description } = node.seo
+                    const { id } = node;
+                    const { pathname } = node.seo;
+                    const title = node.components?.hero?.title;
+                    const { description } = node.seo;
                     return (
-                      <ListItem url={pathname} key={id} iconLeft icon={iconOpt} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
+                      <ListItem
+                        url={pathname}
+                        key={id}
+                        iconLeft
+                        icon={iconOpt}
+                        addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+                      >
                         <div className="d-md-flex">
                           <h3 className="h6 mb-0">
                             <strong>{title}</strong>
                           </h3>
                           <div>
-                            {node.components?.hero?.tag?.label &&
+                            {node.components?.hero?.tag?.label && (
                               <div className="mb-2 mt-1 mb-md-0 mt-md-0">
-                                <Tag label={node.components?.hero?.tag?.label} addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal" />
+                                <Tag
+                                  label={node.components?.hero?.tag?.label}
+                                  addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal"
+                                />
                               </div>
-                            }
+                            )}
                             {node.metadata?.template?.name &&
-                              (node.metadata?.template?.name === 'level1' || node.metadata?.template?.name === 'community') ?
+                            (node.metadata?.template?.name === "level1" ||
+                              node.metadata?.template?.name === "community") ? (
                               <div className="mb-2 mt-1 mb-md-0 mt-md-0 d-table d-sm-table d-md-inline-block ">
-                                <Tag label="Panoramica" addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal" />
+                                <Tag
+                                  label="Panoramica"
+                                  addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal"
+                                />
                               </div>
-                              : null}
+                            ) : null}
                           </div>
                         </div>
-                        {(node.components?.hero?.kangaroo?.eventInfo?.items || description) &&
+                        {(node.components?.hero?.kangaroo?.eventInfo?.items ||
+                          description) && (
                           <p className="text-secondary fw-normal d-block mb-3">
-                            {node.components?.hero?.kangaroo?.eventInfo?.items &&
-                              <small>{node.components?.hero?.kangaroo?.eventInfo?.items[1].label}</small>} {/* // XXX WE NEED AN UNIVERSAL NEWS DATE FIELD */}
+                            {node.components?.hero?.kangaroo?.eventInfo
+                              ?.items && (
+                              <small>
+                                {
+                                  node.components?.hero?.kangaroo?.eventInfo
+                                    ?.items[1].label
+                                }
+                              </small>
+                            )}{" "}
+                            {/* // XXX WE NEED AN UNIVERSAL NEWS DATE FIELD */}
                             <small> — {description}</small>
                           </p>
-                        }
+                        )}
                       </ListItem>
-                    )
+                    );
                   })}
                 </ul>
               </div>
@@ -122,8 +140,8 @@ function ListArchiveEvents({
           </div>
         </div>
       </div>
-    </section >
-  )
+    </section>
+  );
 }
 
-export default ListArchiveEvents
+export default ListArchiveEvents;

--- a/src/components/list-archive-news/list-archive-news.js
+++ b/src/components/list-archive-news/list-archive-news.js
@@ -1,22 +1,18 @@
-import * as React from "react"
+import * as React from "react";
 
-import "../../scss/styles.scss"
-import "../../js/globals"
+import "../../scss/styles.scss";
+import "../../js/globals";
 
-import { useStaticQuery, graphql } from "gatsby"
-import classNames from "classnames"
-import ListItem from "../list-item/list-item"
-import Tag from "../tag/tag"
+import { useStaticQuery, graphql } from "gatsby";
+import classNames from "classnames";
+import ListItem from "../list-item/list-item";
+import Tag from "../tag/tag";
 
-function ListArchiveNews({
-  background,
-  noSpace,
-}) {
-
+function ListArchiveNews({ background, noSpace }) {
   const data = useStaticQuery(graphql`
     query {
       allContent(
-        filter: {metadata: {archive: {in: "notizie"}}}
+        filter: { metadata: { archive: { in: "notizie" } } }
         sort: { seo: { pathname: DESC } }
       ) {
         totalCount
@@ -52,25 +48,23 @@ function ListArchiveNews({
         }
       }
     }
-  `)
+  `);
 
-  const { edges } = data.allContent
-  const tagHeader = 'Esplora l’archivio'
+  const { edges } = data.allContent;
+  const tagHeader = "Esplora l’archivio";
 
   const iconOpt = {
-    icon: 'sprites.svg#it-file',
-    size: 'sm',
+    icon: "sprites.svg#it-file",
+    size: "sm",
     color: "primary",
-    addonClasses: 'mt-1 flex-shrink-0 me-1 me-md-3'
-  }
+    addonClasses: "mt-1 flex-shrink-0 me-1 me-md-3",
+  };
 
-  const styles = classNames(
-    'section-editorial',
-  {
+  const styles = classNames("section-editorial", {
     [`bg-${background}`]: background,
-    'py-0': noSpace,
-    'text-white': (background === "dark")
-  })
+    "py-0": noSpace,
+    "text-white": background === "dark",
+  });
 
   return (
     <section className={styles} aria-describedby="archive-list-title">
@@ -78,43 +72,68 @@ function ListArchiveNews({
         <div className="row">
           <div className="col-12 g-0">
             <div className="px-3 px-lg-0 px-lg-5">
-              <h2 className="border-bottom pb-4" id="archive-list-title">{tagHeader}</h2>
+              <h2 className="border-bottom pb-4" id="archive-list-title">
+                {tagHeader}
+              </h2>
               <div className="it-list-wrapper">
                 <ul className="it-list mt-4 mt-md-3">
                   {edges.map(({ node }) => {
-                    const { id } = node
-                    const { pathname } = node.seo
-                    const title = node.components?.hero?.title
-                    const { description } = node.seo
+                    const { id } = node;
+                    const { pathname } = node.seo;
+                    const title = node.components?.hero?.title;
+                    const { description } = node.seo;
                     return (
-                      <ListItem url={pathname} key={id} iconLeft icon={iconOpt} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
+                      <ListItem
+                        url={pathname}
+                        key={id}
+                        iconLeft
+                        icon={iconOpt}
+                        addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+                      >
                         <div className="d-md-flex">
                           <h3 className="h6 mb-0">
                             <strong>{title}</strong>
                           </h3>
                           <div>
-                            {node.components?.hero?.tag?.label &&
+                            {node.components?.hero?.tag?.label && (
                               <div className="mb-2 mt-1 mb-md-0 mt-md-0">
-                                <Tag label={node.components?.hero?.tag?.label} addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal" />
+                                <Tag
+                                  label={node.components?.hero?.tag?.label}
+                                  addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal"
+                                />
                               </div>
-                            }
+                            )}
                             {node.metadata?.template?.name &&
-                              (node.metadata?.template?.name === 'level1' || node.metadata?.template?.name === 'community') ?
+                            (node.metadata?.template?.name === "level1" ||
+                              node.metadata?.template?.name === "community") ? (
                               <div className="mb-2 mt-1 mb-md-0 mt-md-0 d-table d-sm-table d-md-inline-block ">
-                                <Tag label="Panoramica" addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal" />
+                                <Tag
+                                  label="Panoramica"
+                                  addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal"
+                                />
                               </div>
-                              : null}
+                            ) : null}
                           </div>
                         </div>
-                        {(node.components?.hero?.kangaroo?.personalInfo?.items || description) &&
+                        {(node.components?.hero?.kangaroo?.personalInfo
+                          ?.items ||
+                          description) && (
                           <p className="text-secondary fw-normal d-block mb-3">
-                            {node.components?.hero?.kangaroo?.personalInfo?.items &&
-                              <small>{node.components?.hero?.kangaroo?.personalInfo?.items[1].label}</small>} {/* // XXX WE NEED AN UNIVERSAL NEWS DATE FIELD */}
+                            {node.components?.hero?.kangaroo?.personalInfo
+                              ?.items && (
+                              <small>
+                                {
+                                  node.components?.hero?.kangaroo?.personalInfo
+                                    ?.items[1].label
+                                }
+                              </small>
+                            )}{" "}
+                            {/* // XXX WE NEED AN UNIVERSAL NEWS DATE FIELD */}
                             <small> — {description}</small>
                           </p>
-                        }
+                        )}
                       </ListItem>
-                    )
+                    );
                   })}
                 </ul>
               </div>
@@ -122,8 +141,8 @@ function ListArchiveNews({
           </div>
         </div>
       </div>
-    </section >
-  )
+    </section>
+  );
 }
 
-export default ListArchiveNews
+export default ListArchiveNews;

--- a/src/components/list-item/list-item.js
+++ b/src/components/list-item/list-item.js
@@ -1,186 +1,264 @@
-import * as React from "react"
-import Icon from "../icon/icon"
-import Avatar from "../avatar/avatar"
-import Link from "../link/link"
-import ImageResponsive from "../image-responsive/image-responsive"
-import './list-item.scss'
+import * as React from "react";
+import Icon from "../icon/icon";
+import Avatar from "../avatar/avatar";
+import Link from "../link/link";
+import ImageResponsive from "../image-responsive/image-responsive";
+import "./list-item.scss";
 
 function ListItem({
-	url,             // link of item
-	blank,
-	isDropdown,      // true / false
-	children,        // usually label of link
-	active,          // state of the link
-	disabled,        // disabled state
-	label,           // label
-	srBefore,        // screenreader text before label
-	srAfter,         // screenreader text after label
-	text,            // text under the label
-	visuallyHidden,  // screen reader active state
-	divider,
-	textLarge,		  // bigger text
-	ariaLabel,		  // screen reader message
-	icon,
-	iconRight,       // icon on right
-	iconLeft,		  // icon on left
-	simpleList,
-	avatar,
-	img,
-	alt,
-	action,          // arrow right
-	actions,			  // multiple actions right
-	metadata,        // metadata right
-	addonClasses,
-	onClick
+  url, // link of item
+  blank,
+  isDropdown, // true / false
+  children, // usually label of link
+  active, // state of the link
+  disabled, // disabled state
+  label, // label
+  srBefore, // screenreader text before label
+  srAfter, // screenreader text after label
+  text, // text under the label
+  visuallyHidden, // screen reader active state
+  divider,
+  textLarge, // bigger text
+  ariaLabel, // screen reader message
+  icon,
+  iconRight, // icon on right
+  iconLeft, // icon on left
+  simpleList,
+  avatar,
+  img,
+  alt,
+  action, // arrow right
+  actions, // multiple actions right
+  metadata, // metadata right
+  addonClasses,
+  onClick,
 }) {
+  const GATSBY_ACTIVE = "active";
+  let styles = url ? undefined : "list-item";
 
-	const GATSBY_ACTIVE = "active"
-	let styles = url ? undefined : "list-item"
+  // icon render
+  let iconRendered;
+  if (icon) {
+    iconRendered = <Icon {...icon} />;
+  }
+  // icon render simple list
+  let iconRenderedSimpleList;
+  if (icon) {
+    iconRenderedSimpleList = (
+      <div className="it-rounded-icon">
+        <Icon {...icon} />
+      </div>
+    );
+  }
+  // arrow right
+  let actionRendered;
+  if (action) {
+    actionRendered = <Icon {...icon} />;
+  }
 
-	// icon render
-	let iconRendered
-	if (icon) {
-		iconRendered = <Icon {...icon} />
-	}
-	// icon render simple list
-	let iconRenderedSimpleList
-	if (icon) {
-		iconRenderedSimpleList = <div className="it-rounded-icon"><Icon {...icon} /></div>
-	}
-	// arrow right
-	let actionRendered
-	if (action) {
-		actionRendered = <Icon {...icon} />
-	}
-
-	// immagine
-	let imgRendered
-	if (img) {
-		imgRendered = <div className="it-thumb"><ImageResponsive src={img} alt={alt} /></div>
-	}
-	// label
-	if (label) {
+  // immagine
+  let imgRendered;
+  if (img) {
+    imgRendered = (
+      <div className="it-thumb">
+        <ImageResponsive src={img} alt={alt} />
+      </div>
+    );
+  }
+  // label
+  if (label) {
     // eslint-disable-next-line no-param-reassign
-		children = label
-	}
+    children = label;
+  }
 
-	// -avatar
-	let avatarRendered
-	if (avatar) {
-		avatarRendered = <Avatar {...avatar} />
-	}
+  // -avatar
+  let avatarRendered;
+  if (avatar) {
+    avatarRendered = <Avatar {...avatar} />;
+  }
 
-	// link
-	let listContent
-	listContent = <span>{children}</span>
+  // link
+  let listContent;
+  listContent = <span>{children}</span>;
 
-	// screen reader rule
-	let isActive
-	if (active) {
-		isActive = <span className="visually-hidden">{visuallyHidden}</span>
-	}
+  // screen reader rule
+  let isActive;
+  if (active) {
+    isActive = <span className="visually-hidden">{visuallyHidden}</span>;
+  }
 
-	// multiple actions right
-	let actionsRendered
-	let icons
-	if (actions) {
-		let urlHidden = false
-		icons = actions.map((icons, index) => {
-			// to set aria-hidden if an icon on the right side has the same url of the main element
-			if (icons.url === url) urlHidden = true
-			else urlHidden = false
-			//
-			return <Link to={icons.url} target={icons.blank ? '_blank' : undefined} rel={icons.blank ? 'noreferrer' : undefined} aria-label={icons.ariaLabel} aria-hidden={urlHidden ? 'true' : undefined} key={`iconsaction-${  index}`} ><Icon {...icons} /></Link>
-		})
-		actionsRendered = <span className="it-multiple flex-shrink-0">{icons}</span>
-	}
-	// metadata
-	let metadataRendered
-	if (metadata) {
-		metadataRendered = <span className="metadata">{metadata.label}</span>
-		if (metadata.url) {
-			metadataRendered = <Link to="#">{metadataRendered}</Link>
-		}
-	}
-	let metadataActionsRendered
-	// metadata & multiple actions
-	if (metadata && actions) {
-		metadataActionsRendered = <span className="it-multiple flex-shrink-0">{metadataRendered}{icons}</span>
-	}
-	// -se esiste un link
-	if (url) {
-		listContent = <Link activeClassName={GATSBY_ACTIVE} className={`list-item ${active ? ' active' : ''} ${addonClasses ? ` ${  addonClasses}` : ''} ${textLarge ? ' large' : ''} ${iconLeft ? ' left-icon' : ''} ${iconRight ? ' right-icon' : ''} ${isDropdown ? ' dropdown-item' : ''} ${disabled ? ' disabled' : ''}`} aria-disabled={disabled ? 'true' : undefined} aria-label={ariaLabel ? `${ariaLabel} ${children}` : undefined} to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined} onClick={onClick}>{iconLeft ? iconRendered : ''}<span>{children}</span>{isActive}{iconRight ? iconRendered : ''}</Link>
-	}
-	// -se è all'interno di un dropdown
-	if (isDropdown) {
-		listContent = <Link activeClassName={GATSBY_ACTIVE} className={`list-item ${active ? ' active' : ''} ${addonClasses ? ` ${  addonClasses}` : ''} ${textLarge ? ' large' : ''} ${iconLeft ? ' left-icon' : ''} ${iconRight ? ' right-icon' : ''} ${isDropdown ? 'dropdown-item' : ''} ${disabled ? ' disabled' : ''}`} aria-label={ariaLabel ? `${ariaLabel}` : undefined} aria-disabled={disabled ? 'true' : undefined} to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined} onClick={onClick}>{(iconLeft && !disabled) ? iconRendered : ''}<span>{children}</span>{iconRight ? iconRendered : ''}{isActive}</Link>
-	}
-	// - se è una lista semplice
-	if (simpleList) {
-		listContent = <div className="list-item">{
-			iconLeft ? iconRenderedSimpleList : ''}
-			{imgRendered}
-			{avatarRendered}
-			<div className="it-right-zone"><span className="text">{children}</span>
-				{actionRendered}
-				{!metadataActionsRendered ? actionsRendered : ''}
-				{!metadataActionsRendered ? metadataRendered : ''}
-				{metadataActionsRendered}
-			</div>
-		</div>
-		styles = ''
-	}
-	// - se è una lista semplice con link
-	if (simpleList && url) {
-		listContent = <Link className={`list-item ${active ? ' active' : ''}`} to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined}>
-			{iconLeft ? iconRenderedSimpleList : ''}
-			{imgRendered}
-			{avatarRendered}
-			<div className="it-right-zone">
-				<span className="text">
-					{srBefore && <span className="visually-hidden">{srBefore}</span>}
-					{children}
-					{srAfter && <span className="visually-hidden">{srAfter}</span>}
-				</span>
-				{actionRendered}
-				{!metadataActionsRendered ? actionsRendered : ''}
-				{!metadataActionsRendered ? metadataRendered : ''}
-				{metadataActionsRendered}
-			</div>
-		</Link>
-	}
-	// - se è una lista semplice con link ed actions - eg: resources
-	if (simpleList && url && actions) {
-		listContent = <div className={`list-item ${active ? ' active' : ''}`} >
-			{iconLeft ? iconRenderedSimpleList : ''}
-			{imgRendered}
-			{avatarRendered}
-			<div className="it-right-zone">
-				<Link to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined}>
-					<span className="text">
-						{srBefore && <span className="visually-hidden">{srBefore}</span>}
-						{children}
-						{srAfter && <span className="visually-hidden">{srAfter}</span>}
-						{text && <em>{text}</em>}</span>
-				</Link>
-				{actionRendered}
-				{!metadataActionsRendered ? actionsRendered : ''}
-				{!metadataActionsRendered ? metadataRendered : ''}
-				{metadataActionsRendered}
-			</div>
-		</div>
-	}
-	// - se è un divider
-	if (divider) {
-		listContent = <span className="divider" />
-		styles = ''
-	}
+  // multiple actions right
+  let actionsRendered;
+  let icons;
+  if (actions) {
+    let urlHidden = false;
+    icons = actions.map((icons, index) => {
+      // to set aria-hidden if an icon on the right side has the same url of the main element
+      if (icons.url === url) urlHidden = true;
+      else urlHidden = false;
+      //
+      return (
+        <Link
+          to={icons.url}
+          target={icons.blank ? "_blank" : undefined}
+          rel={icons.blank ? "noreferrer" : undefined}
+          aria-label={icons.ariaLabel}
+          aria-hidden={urlHidden ? "true" : undefined}
+          key={`iconsaction-${index}`}
+        >
+          <Icon {...icons} />
+        </Link>
+      );
+    });
+    actionsRendered = (
+      <span className="it-multiple flex-shrink-0">{icons}</span>
+    );
+  }
+  // metadata
+  let metadataRendered;
+  if (metadata) {
+    metadataRendered = <span className="metadata">{metadata.label}</span>;
+    if (metadata.url) {
+      metadataRendered = <Link to="#">{metadataRendered}</Link>;
+    }
+  }
+  let metadataActionsRendered;
+  // metadata & multiple actions
+  if (metadata && actions) {
+    metadataActionsRendered = (
+      <span className="it-multiple flex-shrink-0">
+        {metadataRendered}
+        {icons}
+      </span>
+    );
+  }
+  // -se esiste un link
+  if (url) {
+    listContent = (
+      <Link
+        activeClassName={GATSBY_ACTIVE}
+        className={`list-item ${active ? " active" : ""} ${
+          addonClasses ? ` ${addonClasses}` : ""
+        } ${textLarge ? " large" : ""} ${iconLeft ? " left-icon" : ""} ${
+          iconRight ? " right-icon" : ""
+        } ${isDropdown ? " dropdown-item" : ""} ${disabled ? " disabled" : ""}`}
+        aria-disabled={disabled ? "true" : undefined}
+        aria-label={ariaLabel ? `${ariaLabel} ${children}` : undefined}
+        to={url}
+        target={blank ? "_blank" : undefined}
+        rel={blank ? "noreferrer" : undefined}
+        onClick={onClick}
+      >
+        {iconLeft ? iconRendered : ""}
+        <span>{children}</span>
+        {isActive}
+        {iconRight ? iconRendered : ""}
+      </Link>
+    );
+  }
+  // -se è all'interno di un dropdown
+  if (isDropdown) {
+    listContent = (
+      <Link
+        activeClassName={GATSBY_ACTIVE}
+        className={`list-item ${active ? " active" : ""} ${
+          addonClasses ? ` ${addonClasses}` : ""
+        } ${textLarge ? " large" : ""} ${iconLeft ? " left-icon" : ""} ${
+          iconRight ? " right-icon" : ""
+        } ${isDropdown ? "dropdown-item" : ""} ${disabled ? " disabled" : ""}`}
+        aria-label={ariaLabel ? `${ariaLabel}` : undefined}
+        aria-disabled={disabled ? "true" : undefined}
+        to={url}
+        target={blank ? "_blank" : undefined}
+        rel={blank ? "noreferrer" : undefined}
+        onClick={onClick}
+      >
+        {iconLeft && !disabled ? iconRendered : ""}
+        <span>{children}</span>
+        {iconRight ? iconRendered : ""}
+        {isActive}
+      </Link>
+    );
+  }
+  // - se è una lista semplice
+  if (simpleList) {
+    listContent = (
+      <div className="list-item">
+        {iconLeft ? iconRenderedSimpleList : ""}
+        {imgRendered}
+        {avatarRendered}
+        <div className="it-right-zone">
+          <span className="text">{children}</span>
+          {actionRendered}
+          {!metadataActionsRendered ? actionsRendered : ""}
+          {!metadataActionsRendered ? metadataRendered : ""}
+          {metadataActionsRendered}
+        </div>
+      </div>
+    );
+    styles = "";
+  }
+  // - se è una lista semplice con link
+  if (simpleList && url) {
+    listContent = (
+      <Link
+        className={`list-item ${active ? " active" : ""}`}
+        to={url}
+        target={blank ? "_blank" : undefined}
+        rel={blank ? "noreferrer" : undefined}
+      >
+        {iconLeft ? iconRenderedSimpleList : ""}
+        {imgRendered}
+        {avatarRendered}
+        <div className="it-right-zone">
+          <span className="text">
+            {srBefore && <span className="visually-hidden">{srBefore}</span>}
+            {children}
+            {srAfter && <span className="visually-hidden">{srAfter}</span>}
+          </span>
+          {actionRendered}
+          {!metadataActionsRendered ? actionsRendered : ""}
+          {!metadataActionsRendered ? metadataRendered : ""}
+          {metadataActionsRendered}
+        </div>
+      </Link>
+    );
+  }
+  // - se è una lista semplice con link ed actions - eg: resources
+  if (simpleList && url && actions) {
+    listContent = (
+      <div className={`list-item ${active ? " active" : ""}`}>
+        {iconLeft ? iconRenderedSimpleList : ""}
+        {imgRendered}
+        {avatarRendered}
+        <div className="it-right-zone">
+          <Link
+            to={url}
+            target={blank ? "_blank" : undefined}
+            rel={blank ? "noreferrer" : undefined}
+          >
+            <span className="text">
+              {srBefore && <span className="visually-hidden">{srBefore}</span>}
+              {children}
+              {srAfter && <span className="visually-hidden">{srAfter}</span>}
+              {text && <em>{text}</em>}
+            </span>
+          </Link>
+          {actionRendered}
+          {!metadataActionsRendered ? actionsRendered : ""}
+          {!metadataActionsRendered ? metadataRendered : ""}
+          {metadataActionsRendered}
+        </div>
+      </div>
+    );
+  }
+  // - se è un divider
+  if (divider) {
+    listContent = <span className="divider" />;
+    styles = "";
+  }
 
-	return (
-		<li className={styles}>
-			{listContent}
-		</li>
-	)
+  return <li className={styles}>{listContent}</li>;
 }
 
-export default ListItem
+export default ListItem;

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -1,130 +1,164 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useState } from "react";
 
-import ListItem from "../list-item/list-item"
-import Link from "../link/link"
-import "./list.scss"
+import ListItem from "../list-item/list-item";
+import Link from "../link/link";
+import "./list.scss";
 
-const List = React.forwardRef(({
-  isMenu,       // is list inside nav menu: true or false
-  isShare,      // is list a share: true or false
-  collapsable,  // true / false
-  isDropdown,   // if inside dropdown
-  id,
-  title,
-  headingLevel,
-  textLarge,
-  children,
-  customStyle,
-  customStyleUl,
-  heading,		    // if has heading
-  headingLink,    // if heading has link
-  listItems,
-  simpleList,
-  shareUrl,
-  shareTitle,
-}, ref) => {
-  const [currentUrl, setCurrentUrl] = useState('')
-  const [currentTitle, setCurrentTitle] = useState('')
+const List = React.forwardRef(
+  (
+    {
+      isMenu, // is list inside nav menu: true or false
+      isShare, // is list a share: true or false
+      collapsable, // true / false
+      isDropdown, // if inside dropdown
+      id,
+      title,
+      headingLevel,
+      textLarge,
+      children,
+      customStyle,
+      customStyleUl,
+      heading, // if has heading
+      headingLink, // if heading has link
+      listItems,
+      simpleList,
+      shareUrl,
+      shareTitle,
+    },
+    ref,
+  ) => {
+    const [currentUrl, setCurrentUrl] = useState("");
+    const [currentTitle, setCurrentTitle] = useState("");
 
-  const ICON_ARROW_RIGHT_TRIANGLE = {
-		icon: "sprites.svg#it-arrow-right-triangle",
-		size: "sm",
-		color: "primary",
-		addonClasses: "align-middle me-2",
-    // ariaLabel: ""
-	  }
+    const ICON_ARROW_RIGHT_TRIANGLE = {
+      icon: "sprites.svg#it-arrow-right-triangle",
+      size: "sm",
+      color: "primary",
+      addonClasses: "align-middle me-2",
+      // ariaLabel: ""
+    };
 
-  useEffect(() => {
-    const url = shareUrl
-      ? new URL(shareUrl, window.location.href).toString()
-      : window.location.href;
+    useEffect(() => {
+      const url = shareUrl
+        ? new URL(shareUrl, window.location.href).toString()
+        : window.location.href;
 
-    setCurrentUrl(url)
-    setCurrentTitle(shareTitle)
-  }, [shareUrl, shareTitle])
+      setCurrentUrl(url);
+      setCurrentTitle(shareTitle);
+    }, [shareUrl, shareTitle]);
 
-  // heading level
-  let HLevel
-  if (headingLevel) {
-    HLevel = `h${headingLevel}`;
-  } else {
-    HLevel = `h3`
-  }
-
-  const styles = `${isMenu ? 'link-list-wrapper' : 'it-list-wrapper'}`
-    + `${collapsable ? ' collapse' : ''}`
-    + `${customStyle ? ` ${  customStyle}` : ''}`
-
-  const ulStyles = `${isMenu ? 'link-list' : 'it-list'}`
-    + `${customStyleUl ? ` ${  customStyleUl}` : ''}`
-
-  if (isShare) {
-    const iconProps = { color: 'primary', size: 'sm' }
-    const onCopyLink = async () => {
-      await navigator.clipboard.writeText(currentUrl);
-    }
-
-    // eslint-disable-next-line no-param-reassign
-    children = (
-      <>
-        <ListItem
-          label="Copia collegamento"
-          icon={{ icon: 'sprites.svg#it-copy', ...iconProps }}
-          iconRight isDropdown={isDropdown}
-          textLarge={textLarge} simpleList={simpleList}
-          ariaLabel=""
-          url="#"
-          onClick={onCopyLink}
-        />
-        <ListItem
-          label="Condividi su Twitter"
-          icon={{ icon: 'sprites.svg#it-twitter', ...iconProps }}
-          iconRight isDropdown={isDropdown}
-          textLarge={textLarge} simpleList={simpleList}
-          ariaLabel="Condividi su Twitter (si apre in una nuova finestra)"
-          url={`https://twitter.com/intent/tweet/?text=${currentTitle}&url=${currentUrl}`}
-          blank="true"
-        />
-        <ListItem
-          label="Condividi su LinkedIn"
-          icon={{ icon: 'sprites.svg#it-linkedin', ...iconProps }}
-          iconRight isDropdown={isDropdown}
-          textLarge={textLarge} simpleList={simpleList}
-          ariaLabel="Condividi su LinkedIn (si apre in una nuova finestra)"
-          url={`https://www.linkedin.com/sharing/share-offsite/?url=${currentUrl}`}
-          blank="true"
-        />
-      </>
-    )
-  }
-
-  if (listItems) {
-    if (isMenu) { // megamenu
-      // eslint-disable-next-line no-param-reassign
-      children = listItems.map((listitems, index) => <ListItem {...listitems} key={`z-list-${  index}`} isDropdown={isDropdown} textLarge={textLarge} simpleList={simpleList} icon={ICON_ARROW_RIGHT_TRIANGLE} iconLeft />)
+    // heading level
+    let HLevel;
+    if (headingLevel) {
+      HLevel = `h${headingLevel}`;
     } else {
+      HLevel = `h3`;
+    }
+
+    const styles =
+      `${isMenu ? "link-list-wrapper" : "it-list-wrapper"}` +
+      `${collapsable ? " collapse" : ""}` +
+      `${customStyle ? ` ${customStyle}` : ""}`;
+
+    const ulStyles =
+      `${isMenu ? "link-list" : "it-list"}` +
+      `${customStyleUl ? ` ${customStyleUl}` : ""}`;
+
+    if (isShare) {
+      const iconProps = { color: "primary", size: "sm" };
+      const onCopyLink = async () => {
+        await navigator.clipboard.writeText(currentUrl);
+      };
+
       // eslint-disable-next-line no-param-reassign
-      children = listItems.map((listitems, index) => <ListItem {...listitems} key={`z-list-${  index}`} isDropdown={isDropdown} textLarge={textLarge} simpleList={simpleList} />)
+      children = (
+        <>
+          <ListItem
+            label="Copia collegamento"
+            icon={{ icon: "sprites.svg#it-copy", ...iconProps }}
+            iconRight
+            isDropdown={isDropdown}
+            textLarge={textLarge}
+            simpleList={simpleList}
+            ariaLabel=""
+            url="#"
+            onClick={onCopyLink}
+          />
+          <ListItem
+            label="Condividi su Twitter"
+            icon={{ icon: "sprites.svg#it-twitter", ...iconProps }}
+            iconRight
+            isDropdown={isDropdown}
+            textLarge={textLarge}
+            simpleList={simpleList}
+            ariaLabel="Condividi su Twitter (si apre in una nuova finestra)"
+            url={`https://twitter.com/intent/tweet/?text=${currentTitle}&url=${currentUrl}`}
+            blank="true"
+          />
+          <ListItem
+            label="Condividi su LinkedIn"
+            icon={{ icon: "sprites.svg#it-linkedin", ...iconProps }}
+            iconRight
+            isDropdown={isDropdown}
+            textLarge={textLarge}
+            simpleList={simpleList}
+            ariaLabel="Condividi su LinkedIn (si apre in una nuova finestra)"
+            url={`https://www.linkedin.com/sharing/share-offsite/?url=${currentUrl}`}
+            blank="true"
+          />
+        </>
+      );
     }
-  }
 
-  let ListHeading
-  if (heading) {
-    ListHeading = <div className="link-list-heading">{heading}</div>
-    if (headingLink) {
-      ListHeading = <div className="link-list-heading"><Link to={headingLink}>{heading}</Link></div>
+    if (listItems) {
+      if (isMenu) {
+        // megamenu
+        // eslint-disable-next-line no-param-reassign
+        children = listItems.map((listitems, index) => (
+          <ListItem
+            {...listitems}
+            key={`z-list-${index}`}
+            isDropdown={isDropdown}
+            textLarge={textLarge}
+            simpleList={simpleList}
+            icon={ICON_ARROW_RIGHT_TRIANGLE}
+            iconLeft
+          />
+        ));
+      } else {
+        // eslint-disable-next-line no-param-reassign
+        children = listItems.map((listitems, index) => (
+          <ListItem
+            {...listitems}
+            key={`z-list-${index}`}
+            isDropdown={isDropdown}
+            textLarge={textLarge}
+            simpleList={simpleList}
+          />
+        ));
+      }
     }
-  }
 
-  return (
-    <div ref={ref} className={styles} id={id}>
-      {ListHeading}
-      {title && <HLevel className="title h4 mb-0">{title}</HLevel>}
-      <ul className={ulStyles}>
-        {children}
-      </ul>
-    </div>
-  )
-})
+    let ListHeading;
+    if (heading) {
+      ListHeading = <div className="link-list-heading">{heading}</div>;
+      if (headingLink) {
+        ListHeading = (
+          <div className="link-list-heading">
+            <Link to={headingLink}>{heading}</Link>
+          </div>
+        );
+      }
+    }
 
-export default List
+    return (
+      <div ref={ref} className={styles} id={id}>
+        {ListHeading}
+        {title && <HLevel className="title h4 mb-0">{title}</HLevel>}
+        <ul className={ulStyles}>{children}</ul>
+      </div>
+    );
+  },
+);
+
+export default List;

--- a/src/components/megamenu/megamenu.js
+++ b/src/components/megamenu/megamenu.js
@@ -1,63 +1,70 @@
-import * as React from "react"
-import ReactMarkdown from "react-markdown"
-import List from "../list/list"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import './megamenu.scss'
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import List from "../list/list";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import "./megamenu.scss";
 
-import ImageResponsive from "../image-responsive/image-responsive"
+import ImageResponsive from "../image-responsive/image-responsive";
 
-function Megamenu({
-	left,
-	heading,
-	cols
-}) {
+function Megamenu({ left, heading, cols }) {
+  const GATSBY_ACTIVE = "active";
 
-	const GATSBY_ACTIVE = "active"
-
-	return (
-		<div className="megamenu pb-5 pb-lg-0">
-			<div className="row">
-				<div className="col-xs-12 col-lg-4 px-0">
-					<div className="row">
-						{left &&
-							<div className="col-12 it-vertical it-description pb-lg-3">
-								<div className="description-content img-max-megamenu ps-4 ps-sm-5 ms-3">
-									{left.img &&
-										<div className="ratio ratio-megamenu lightgrey-bg-a1 mb-4 rounded">
-											<ImageResponsive className="rounded" src={left.img} alt={left.imgAlt} loading="eager" />
-										</div>
-									}
-									{left.text &&
-										<ReactMarkdown>{left.text}</ReactMarkdown>
-									}
-								</div>
-							</div>
-						}
-					</div>
-				</div>
-				<div className="col-12 col-lg-8">
-					{heading &&
-						<div className="heading-link-wrapper">
-							<Link className="heading-link d-flex-inline align-items-center" to={heading.url} activeClassName={GATSBY_ACTIVE}>
-								<Icon icon="sprites.svg#it-arrow-right-triangle" size="sm" color="primary" addonClasses="me-2" />
-								<span>{heading.label}</span>
-							</Link>
-						</div>
-					}
-					{cols &&
-						<div className="row">
-							{cols.map((col, index) => (
-									<div key={`megalist-${  index}`} className="col-12 col-lg-6">
-										<List {...col} isDropdown="true" />
-									</div>
-								))}
-						</div>
-					}
-				</div>
-			</div>
-		</div>
-	)
+  return (
+    <div className="megamenu pb-5 pb-lg-0">
+      <div className="row">
+        <div className="col-xs-12 col-lg-4 px-0">
+          <div className="row">
+            {left && (
+              <div className="col-12 it-vertical it-description pb-lg-3">
+                <div className="description-content img-max-megamenu ps-4 ps-sm-5 ms-3">
+                  {left.img && (
+                    <div className="ratio ratio-megamenu lightgrey-bg-a1 mb-4 rounded">
+                      <ImageResponsive
+                        className="rounded"
+                        src={left.img}
+                        alt={left.imgAlt}
+                        loading="eager"
+                      />
+                    </div>
+                  )}
+                  {left.text && <ReactMarkdown>{left.text}</ReactMarkdown>}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="col-12 col-lg-8">
+          {heading && (
+            <div className="heading-link-wrapper">
+              <Link
+                className="heading-link d-flex-inline align-items-center"
+                to={heading.url}
+                activeClassName={GATSBY_ACTIVE}
+              >
+                <Icon
+                  icon="sprites.svg#it-arrow-right-triangle"
+                  size="sm"
+                  color="primary"
+                  addonClasses="me-2"
+                />
+                <span>{heading.label}</span>
+              </Link>
+            </div>
+          )}
+          {cols && (
+            <div className="row">
+              {cols.map((col, index) => (
+                <div key={`megalist-${index}`} className="col-12 col-lg-6">
+                  <List {...col} isDropdown="true" />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }
 
-export default Megamenu
+export default Megamenu;

--- a/src/components/nav-other-links/nav-other-links.js
+++ b/src/components/nav-other-links/nav-other-links.js
@@ -1,43 +1,38 @@
-import React from "react"
-import Icon from "../icon/icon"
-import LinkCustom from "../link-custom/link-custom"
+import React from "react";
+import Icon from "../icon/icon";
+import LinkCustom from "../link-custom/link-custom";
 
-function NavOtherLinks({
-  icon,
-  title,
-  items
-}) {
-
-  let linkItems
+function NavOtherLinks({ icon, title, items }) {
+  let linkItems;
 
   if (items) {
-    linkItems = items.map((item,index) => {
+    linkItems = items.map((item, index) => {
       // eslint-disable-next-line no-param-reassign
-      item.imageClass = "me-3"
-      return(
-        <div className="col-10 mb-2 mb-md-0 col-md-6 col-lg-3" key={`link-${index}`}>
-          <LinkCustom {...item}/>
+      item.imageClass = "me-3";
+      return (
+        <div
+          className="col-10 mb-2 mb-md-0 col-md-6 col-lg-3"
+          key={`link-${index}`}
+        >
+          <LinkCustom {...item} />
         </div>
-      )
-    })
+      );
+    });
   }
-
 
   return (
     <div className="nav-other-links pb-5">
       <div className="container-xxl">
-      <div className="row">
-        <p className="d-flex align-items-center small text-uppercase text-secondary">
-          <Icon {...icon}/>
-          <strong>{title}</strong>
-        </p>
-      </div>
         <div className="row">
-          {linkItems}
+          <p className="d-flex align-items-center small text-uppercase text-secondary">
+            <Icon {...icon} />
+            <strong>{title}</strong>
+          </p>
         </div>
+        <div className="row">{linkItems}</div>
       </div>
     </div>
-  )
+  );
 }
 
-export default NavOtherLinks
+export default NavOtherLinks;

--- a/src/components/nav-other-prev-next/nav-other-prev-next.js
+++ b/src/components/nav-other-prev-next/nav-other-prev-next.js
@@ -1,19 +1,15 @@
-import React from "react"
-import LinkCustom from "../link-custom/link-custom"
+import React from "react";
+import LinkCustom from "../link-custom/link-custom";
 
-function NavOtherPrevNext({
-  prev,
-  next
-}) {
-
+function NavOtherPrevNext({ prev, next }) {
   if (prev) {
     // eslint-disable-next-line no-param-reassign
-    prev.imageClass = "mx-3"
+    prev.imageClass = "mx-3";
   }
 
   if (next) {
     // eslint-disable-next-line no-param-reassign
-    next.imageClass = "mx-3"
+    next.imageClass = "mx-3";
   }
 
   return (
@@ -21,15 +17,15 @@ function NavOtherPrevNext({
       <div className="container-xxl">
         <div className="row">
           <div className="col mb-4 mb-md-0 col-md-5 col-lg-4 col-xl-3">
-            {prev && <LinkCustom {...prev}/>}
+            {prev && <LinkCustom {...prev} />}
           </div>
           <div className="col col-md-5 offset-md-2 col-lg-4 offset-lg-4 col-xl-3 offset-xl-6 d-flex justify-content-end">
-            {next && <LinkCustom {...next}/>}
+            {next && <LinkCustom {...next} />}
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default NavOtherPrevNext
+export default NavOtherPrevNext;

--- a/src/components/nav-position/nav-position.js
+++ b/src/components/nav-position/nav-position.js
@@ -1,57 +1,65 @@
-import React from "react"
-import ReactMarkdown from "react-markdown"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import Tooltip from "../tooltip/tooltip"
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import Tooltip from "../tooltip/tooltip";
 
-function NavPosition({
-  items,
-  footerVersion
-}) {
+function NavPosition({ items, footerVersion }) {
+  const containerStyles =
+    "nav-position" +
+    `${
+      footerVersion
+        ? " py-5 border-top neutral-1-border-color-a3 border-end-0 border-start-0 border-bottom-0"
+        : ""
+    }`;
 
-  const containerStyles = "nav-position"
-    + `${footerVersion ? ' py-5 border-top neutral-1-border-color-a3 border-end-0 border-start-0 border-bottom-0' : ''}`
-
-  let linkItems
+  let linkItems;
 
   if (items) {
     linkItems = items.map((item, index) => {
       // eslint-disable-next-line no-param-reassign
-      item.icon.addonClasses = "flex-shrink-0 me-3"
+      item.icon.addonClasses = "flex-shrink-0 me-3";
       // eslint-disable-next-line no-param-reassign
-      item.icon.hidden = true
+      item.icon.hidden = true;
       return (
-        <div key={`linkItems-${  index}`} >
+        <div key={`linkItems-${index}`}>
           <div className="d-inline-flex align-items-center me-lg-5 my-2 small">
             <Icon {...item.icon} />
-            <span className="text-uppercase text-secondary me-2"><strong>{item.title}</strong></span>
-            {item.tooltip &&
-              <Tooltip label={item.tooltip} />
-            }
+            <span className="text-uppercase text-secondary me-2">
+              <strong>{item.title}</strong>
+            </span>
+            {item.tooltip && <Tooltip label={item.tooltip} />}
             <div className="ms-3">
-              {item.url ? <Link to={item.url} target={item.blank ? '_blank' : undefined} rel={item.blank ? 'noreferrer' : undefined}>
-                {item.label}
-                {item.screenReaderText &&
-                  <span className="visually-hidden">{item.screenReaderText}</span>
-                }</Link> : <span>{item.label}</span>}
+              {item.url ? (
+                <Link
+                  to={item.url}
+                  target={item.blank ? "_blank" : undefined}
+                  rel={item.blank ? "noreferrer" : undefined}
+                >
+                  {item.label}
+                  {item.screenReaderText && (
+                    <span className="visually-hidden">
+                      {item.screenReaderText}
+                    </span>
+                  )}
+                </Link>
+              ) : (
+                <span>{item.label}</span>
+              )}
             </div>
           </div>
-          <div>
-            {item.text && <ReactMarkdown>{item.text}</ReactMarkdown>}
-          </div>
+          <div>{item.text && <ReactMarkdown>{item.text}</ReactMarkdown>}</div>
         </div>
-      )
-    })
+      );
+    });
   }
   return (
     <div className={containerStyles}>
       <div className="container-xxl">
-        <div className="row">
-          {linkItems}
-        </div>
+        <div className="row">{linkItems}</div>
       </div>
     </div>
-  )
+  );
 }
 
-export default NavPosition
+export default NavPosition;

--- a/src/components/nav-pre-footer/nav-pre-footer.js
+++ b/src/components/nav-pre-footer/nav-pre-footer.js
@@ -1,20 +1,16 @@
-import React from "react"
-import NavPosition from "../nav-position/nav-position"
-import NavOtherLinks from "../nav-other-links/nav-other-links"
-import NavOtherPrevNext from "../nav-other-prev-next/nav-other-prev-next"
+import React from "react";
+import NavPosition from "../nav-position/nav-position";
+import NavOtherLinks from "../nav-other-links/nav-other-links";
+import NavOtherPrevNext from "../nav-other-prev-next/nav-other-prev-next";
 
-function NavPreFooter({
-  navPosition,
-  navOtherLinks,
-  navOtherPrevNext
-}) {
+function NavPreFooter({ navPosition, navOtherLinks, navOtherPrevNext }) {
   return (
     <div className="nav-pre-footer">
-      {navPosition && <NavPosition items={navPosition}/>}
-      {navOtherLinks && <NavOtherLinks {...navOtherLinks}/>}
-      {navOtherPrevNext && <NavOtherPrevNext {...navOtherPrevNext}/>}
+      {navPosition && <NavPosition items={navPosition} />}
+      {navOtherLinks && <NavOtherLinks {...navOtherLinks} />}
+      {navOtherPrevNext && <NavOtherPrevNext {...navOtherPrevNext} />}
     </div>
-  )
+  );
 }
 
-export default NavPreFooter
+export default NavPreFooter;

--- a/src/components/nav-sidebar/nav-sidebar.js
+++ b/src/components/nav-sidebar/nav-sidebar.js
@@ -1,9 +1,10 @@
-import React, { useRef, useEffect } from "react"
-import { NavBarCollapsible, Sticky } from "bootstrap-italia"
-import Tag from "../tag/tag"
-import Link from "../link/link"
+import classNames from "classnames";
+import React, { useRef, useEffect } from "react";
+import { NavBarCollapsible, Sticky } from "bootstrap-italia";
+import Tag from "../tag/tag";
+import Link from "../link/link";
 import BackToTopEl from "../back-to-top/back-to-top";
-import "./nav-sidebar.scss"
+import "./nav-sidebar.scss";
 
 import FooterData from "../../data/footer.yaml";
 import Icon from "../icon/icon";
@@ -23,129 +24,169 @@ function NavSidebar({
   buttonCloseAriaLabel,
   list,
   secondaryList,
-  page
+  page,
 }) {
+  let links;
+  let linksStyle;
+  let subLinks;
+  let expandSublinks;
+  let subStyles;
+  let secondaryLinks;
 
-  let links
-  let linksStyle
-  let subLinks
-  let expandSublinks
-  let subStyles
-  let secondaryLinks
-
-  const GATSBY_ACTIVE = "active"
-  const navCollRef = useRef(null)
-  const navStickyRef = useRef(null)
+  const GATSBY_ACTIVE = "active";
+  const navCollRef = useRef(null);
+  const navStickyRef = useRef(null);
 
   const ICON_CHEVRON_RIGHT = {
     icon: "sprites.svg#it-chevron-right",
     size: "sm",
     color: "primary",
     addonClasses: "align-middle",
-    ariaLabel: " (Link esterno)"
-  }
+    ariaLabel: " (Link esterno)",
+  };
 
   if (list) {
-    links = list.map((item,index) => {
+    links = list.map((item, index) => {
+      expandSublinks = false;
 
-      expandSublinks = false
-
-      linksStyle = "list-item text-uppercase right-icon"
-        + `${(item.label === page) ? ' active' : ''}`
-        + `${(item.disabled) ? ' disabled' : ''}`
+      linksStyle =
+        "list-item text-uppercase right-icon" +
+        `${item.label === page ? " active" : ""}` +
+        `${item.disabled ? " disabled" : ""}`;
 
       if (item.subList) {
-
-        subLinks = item.subList.map((subItem,indexSub) => {
-
+        subLinks = item.subList.map((subItem, indexSub) => {
           if (subItem.label === page) {
-            expandSublinks = true
-            linksStyle +=' contains-active'
+            expandSublinks = true;
+            linksStyle += " contains-active";
           }
 
-          let subLiStyle
+          let subLiStyle;
 
           if (subItem.disabled) {
-            subLiStyle = 'disabled'
+            subLiStyle = "disabled";
           }
 
           return (
-             <li key={`subl-${indexSub}`}>
-              <Link to={subItem.url} className={subLiStyle} activeClassName={GATSBY_ACTIVE}><span>{subItem.label}</span></Link>
+            <li key={`subl-${indexSub}`}>
+              <Link
+                to={subItem.url}
+                className={subLiStyle}
+                activeClassName={GATSBY_ACTIVE}
+              >
+                <span>{subItem.label}</span>
+              </Link>
             </li>
-          )
-        })
+          );
+        });
 
-        subStyles = "link-sublist collapse"
-          + `${expandSublinks ? ' show' : ''}`
+        subStyles = classNames("link-sublist collapse", {
+          show: expandSublinks,
+        });
 
-        return(
+        return (
           <li key={`l-${index}`}>
-            <button type="button" className={linksStyle} data-bs-target={`#collapseNav-${index}`} data-bs-toggle="collapse" aria-expanded={expandSublinks} aria-controls={`collapseNav-${index}`}>
+            <button
+              type="button"
+              className={linksStyle}
+              data-bs-target={`#collapseNav-${index}`}
+              data-bs-toggle="collapse"
+              aria-expanded={expandSublinks}
+              aria-controls={`collapseNav-${index}`}
+            >
               <span className="list-item-title-icon-wrapper list-item-title-icon-wrapper d-flex justify-content-between align-items-center">
                 <span>{item.label}</span>
-                <svg role="img" className="icon icon-sm icon-primary right" aria-hidden="true"><use href="/svg/sprites.svg#it-expand" /></svg>
+                <svg
+                  role="img"
+                  className="icon icon-sm icon-primary right"
+                  aria-hidden="true"
+                >
+                  <use href="/svg/sprites.svg#it-expand" />
+                </svg>
               </span>
             </button>
             <ul className={subStyles} id={`collapseNav-${index}`}>
               {subLinks}
             </ul>
           </li>
-        )
+        );
       }
-        return(
-          <li key={`l-${index}`}>
-            <Link className={linksStyle} to={item.url} activeClassName={GATSBY_ACTIVE}>
-              <span>{item.label}</span>
-            </Link>
-          </li>
-        )
-
-
-    })
-  }
-
-  if (secondaryList) {
-
-    secondaryLinks = secondaryList.map((item,index) => {
-      const secondaryItemStyle = "list-item"
-      + `${(item.disabled) ? ' disabled' : ''}`
-
-      return(
-        <li key={`sl-${index}`}>
-          <Link className={secondaryItemStyle} to={item.url} activeClassName={GATSBY_ACTIVE}>
+      return (
+        <li key={`l-${index}`}>
+          <Link
+            className={linksStyle}
+            to={item.url}
+            activeClassName={GATSBY_ACTIVE}
+          >
             <span>{item.label}</span>
           </Link>
         </li>
-      )
-    })
+      );
+    });
+  }
+
+  if (secondaryList) {
+    secondaryLinks = secondaryList.map((item, index) => {
+      const secondaryItemStyle = classNames("list-item", {
+        disabled: item.disabled,
+      });
+
+      return (
+        <li key={`sl-${index}`}>
+          <Link
+            className={secondaryItemStyle}
+            to={item.url}
+            activeClassName={GATSBY_ACTIVE}
+          >
+            <span>{item.label}</span>
+          </Link>
+        </li>
+      );
+    });
   }
 
   useEffect(() => {
-    const navColl = navCollRef.current
-    const navSticky = navStickyRef.current
+    const navColl = navCollRef.current;
+    const navSticky = navStickyRef.current;
     if (navSticky) {
       // eslint-disable-next-line no-new
       new Sticky(navSticky, {
         stackable: true,
-        paddingTop: 100
-      })
+        paddingTop: 100,
+      });
     }
     return () => {
       if (navColl) {
-        const navCollObj = new NavBarCollapsible(navColl)
+        const navCollObj = new NavBarCollapsible(navColl);
         if (navCollObj) {
-          navCollObj.hide()
+          navCollObj.hide();
         }
       }
-    }
-  })
+    };
+  });
 
   return (
-    <div className="col-12 col-lg-3 px-lg-0 bg-light menu-column border-end bs-is-sticky" ref={navStickyRef}>
+    <div
+      className="col-12 col-lg-3 px-lg-0 bg-light menu-column border-end bs-is-sticky"
+      ref={navStickyRef}
+    >
       <div className="nav-sidebar">
-        <nav className="navbar it-navscroll-wrapper navbar-expand-lg it-bottom-navscroll it-left-side border-start-0 border-top" aria-label={ariaLabel}>
-          <button className="custom-navbar-toggler" type="button" aria-controls={id} aria-expanded="false" aria-label={toggleAriaLabel} data-bs-toggle="navbarcollapsible" data-bs-target="#navSidebarDs"><span className="it-list" /><Icon {...ICON_CHEVRON_RIGHT} />{toggleLabel}
+        <nav
+          className="navbar it-navscroll-wrapper navbar-expand-lg it-bottom-navscroll it-left-side border-start-0 border-top"
+          aria-label={ariaLabel}
+        >
+          <button
+            className="custom-navbar-toggler"
+            type="button"
+            aria-controls={id}
+            aria-expanded="false"
+            aria-label={toggleAriaLabel}
+            data-bs-toggle="navbarcollapsible"
+            data-bs-target="#navSidebarDs"
+          >
+            <span className="it-list" />
+            <Icon {...ICON_CHEVRON_RIGHT} />
+            {toggleLabel}
           </button>
           <BackToTopEl
             positionTop={0}
@@ -158,7 +199,8 @@ function NavSidebar({
             <div className="overlay" />
             <div className="close-div visually-hidden">
               <button className="btn close-menu" type="button">
-                <span className="it-close" />{buttonCloseAriaLabel}
+                <span className="it-close" />
+                {buttonCloseAriaLabel}
               </button>
             </div>
             <a className="it-back-button" href="#" role="button">
@@ -168,39 +210,32 @@ function NavSidebar({
               <span>{backLabel}</span>
             </a>
             <div className="menu-wrapper">
-
-            <div className="nav-sidebar-header mx-4 mx-lg-3 mb-4 mb-lg-5 mt-0 mt-lg-3">
-              <a className="" href={url}>
-                <img src={img} className="header-image my-2" alt={alt}/>
-                <h2 className="h4 text-primary">{title}</h2>
-              </a>
-              <p className="lead fw-normal w-75">{subTitle}</p>
-              { tag && <Tag {...tag}/>}
-            </div>
-
-              <div className="link-list-wrapper">
-                <ul className="link-list">
-                  {links}
-                </ul>
+              <div className="nav-sidebar-header mx-4 mx-lg-3 mb-4 mb-lg-5 mt-0 mt-lg-3">
+                <a className="" href={url}>
+                  <img src={img} className="header-image my-2" alt={alt} />
+                  <h2 className="h4 text-primary">{title}</h2>
+                </a>
+                <p className="lead fw-normal w-75">{subTitle}</p>
+                {tag && <Tag {...tag} />}
               </div>
 
-              { secondaryLinks &&
+              <div className="link-list-wrapper">
+                <ul className="link-list">{links}</ul>
+              </div>
+
+              {secondaryLinks && (
                 <div className="sidebar-linklist-wrapper linklist-secondary">
                   <div className="link-list-wrapper">
-                    <ul className="link-list">
-                      {secondaryLinks}
-                    </ul>
+                    <ul className="link-list">{secondaryLinks}</ul>
                   </div>
                 </div>
-              }
-
+              )}
             </div>
-
           </div>
         </nav>
       </div>
     </div>
-  )
+  );
 }
 
-export default NavSidebar
+export default NavSidebar;

--- a/src/components/nav-wrapper/nav-wrapper.js
+++ b/src/components/nav-wrapper/nav-wrapper.js
@@ -1,11 +1,7 @@
-import React from "react"
+import React from "react";
 
-function NavWrapper({children}) {
-	return(
-		<div className="it-nav-wrapper">
-			{children}
-		</div>
-	)
+function NavWrapper({ children }) {
+  return <div className="it-nav-wrapper">{children}</div>;
 }
 
-export default NavWrapper
+export default NavWrapper;

--- a/src/components/numbers/numbers.js
+++ b/src/components/numbers/numbers.js
@@ -1,40 +1,33 @@
-import React from "react"
-import "./numbers.scss"
-import Icon from "../icon/icon"
+import React from "react";
+import "./numbers.scss";
+import Icon from "../icon/icon";
 
-function Numbers({
-  items,
-  inline
-}) {
-
-
-  const styles = "numbers-wrapper d-sm-flex flex-wrap align-items-end"
-  + `${inline ? ' inline-numbers' : ''}`
+function Numbers({ items, inline }) {
+  const styles =
+    "numbers-wrapper d-sm-flex flex-wrap align-items-end" +
+    `${inline ? " inline-numbers" : ""}`;
 
   // numbers
-	let NumbersRender
-	if (items) {
-		NumbersRender = items.map((num,index) => (
-        <div className="numbers mb-4 mb-sm-4" key={`number-${index}`}>
-          <div className="label mb-2"><small><strong>{num.label}</strong></small></div>
-          <div className="d-flex align-items-center">
-            <Icon
-              icon={num.icon}
-              size="lg"
-              addonClasses="mt-1 me-2"
-              hidden
-            />
-            <div className="number font-monospace fw-normal display-1">{num.number}</div>
+  let NumbersRender;
+  if (items) {
+    NumbersRender = items.map((num, index) => (
+      <div className="numbers mb-4 mb-sm-4" key={`number-${index}`}>
+        <div className="label mb-2">
+          <small>
+            <strong>{num.label}</strong>
+          </small>
+        </div>
+        <div className="d-flex align-items-center">
+          <Icon icon={num.icon} size="lg" addonClasses="mt-1 me-2" hidden />
+          <div className="number font-monospace fw-normal display-1">
+            {num.number}
           </div>
         </div>
-			))
-	}
+      </div>
+    ));
+  }
 
-  return (
-    <div className={styles}>
-      {NumbersRender}
-    </div>
-  )
+  return <div className={styles}>{NumbersRender}</div>;
 }
 
-export default Numbers
+export default Numbers;

--- a/src/components/resource-list/resource-list.js
+++ b/src/components/resource-list/resource-list.js
@@ -1,32 +1,28 @@
-import React from "react"
-import List from "../list/list"
+import React from "react";
+import List from "../list/list";
 
-function ResourceList({
-  title,
-  headingLevel,
-  list,
-  full
-}) {
-
+function ResourceList({ title, headingLevel, list, full }) {
   // heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h3`
-	}
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h3`;
+  }
 
-  const addonClasses = full ? ' px-0 mx-0 w-100 pb-5' : 'col-12 col-md-10 offset-md-1 col-lg-9 offset-lg-0 pb-5'
-  let listItem
+  const addonClasses = full
+    ? " px-0 mx-0 w-100 pb-5"
+    : "col-12 col-md-10 offset-md-1 col-lg-9 offset-lg-0 pb-5";
+  let listItem;
 
   if (list) {
-    listItem = list.map((item,index) => (
-        <div className={addonClasses} key={`list-${index}`}>
-            <div className="px-3 px-lg-0">
-              <List {...item}/>
-            </div>
+    listItem = list.map((item, index) => (
+      <div className={addonClasses} key={`list-${index}`}>
+        <div className="px-3 px-lg-0">
+          <List {...item} />
         </div>
-      ))
+      </div>
+    ));
   }
 
   return (
@@ -34,15 +30,15 @@ function ResourceList({
       <div className="container-xxl">
         <div className="row justify-content-lg-center">
           <div className={addonClasses}>
-              <div className="px-3 px-lg-0">
-                {title && <HLevel className="mb-0">{title}</HLevel>}
-              </div>
+            <div className="px-3 px-lg-0">
+              {title && <HLevel className="mb-0">{title}</HLevel>}
+            </div>
           </div>
           {listItem}
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default ResourceList
+export default ResourceList;

--- a/src/components/search-main/search-main.js
+++ b/src/components/search-main/search-main.js
@@ -8,20 +8,7 @@ import Tag from "../tag/tag";
 import ListItem from "../list-item/list-item";
 import "./search-main.scss";
 
-function SearchMain({
-  location,
-  howMany,
-  isResultsPage,
-  useSuggestionEngine,
-  title,
-  text,
-  formId,
-  label,
-  inputId,
-  button,
-  suggest,
-  background,
-}) {
+function SearchMain({ location, maxResults, title, suggest }) {
   const [input, setInput] = useState(() => location?.state?.searchTerm);
   const [searchTerm, setSearchTerm] = useState(
     () => location?.state?.searchTerm,
@@ -84,16 +71,24 @@ function SearchMain({
   };
 
   const searchOptions = {
-    limit: `${howMany || ""}`,
+    limit: maxResults,
     // if true "fill" the spaces with suggestions, useful for multiple words query XXX
-    suggest: useSuggestionEngine,
+    suggest: false,
   };
 
   const results = useFlexSearch(searchTerm, index, store, searchOptions);
 
-  const styles = classNames("search-main", {
-    [`bg-${background}`]: background,
-  });
+  const styles = classNames("search-main bg-light");
+
+  const searchButton = {
+    label: "Cerca",
+    btnStyle: "primary",
+    iconRight: true,
+    icon: {
+      icon: "sprites.svg#it-search",
+      addonClasses: "ms-1 icon-search",
+    },
+  };
 
   return (
     <section className={styles}>
@@ -104,12 +99,11 @@ function SearchMain({
               className="search-main-content px-3 py-5 px-lg-0 px-lg-5 py-lg-6"
               role="search"
             >
-              {title || text ? (
+              {title && (
                 <div className="text-container mb-5">
                   {title && <h2>{title}</h2>}
-                  {text && <p className="lead">{text}</p>}
                 </div>
-              ) : null}
+              )}
               {suggest && (
                 <div className="suggest-wrapper d-lg-flex mb-3">
                   <h3 className="mb-4">{suggest.title}</h3>
@@ -137,20 +131,17 @@ function SearchMain({
                 </div>
               )}
               <div className="search-form px-3 px-sm-4 pb-4 mb-5 shadow-lg">
-                <form id={formId} onSubmit={formSubmit}>
+                <form id="searchForm" onSubmit={formSubmit}>
                   <div className="d-flex flex-column align-items-center flex-sm-row w-100">
                     <div className="form-group mb-0 flex-grow-1 me-sm-4 w-100">
-                      <label
-                        ref={searchLabelRef}
-                        /* className="active" */ htmlFor={inputId}
-                      >
-                        {label}
+                      <label ref={searchLabelRef} htmlFor="searchInput">
+                        Cerca
                       </label>
                       <input
                         type="search"
                         className="border-search form-control-lg search"
                         name="search"
-                        id={inputId}
+                        id="searchInput"
                         placeholder=""
                         autoComplete="off"
                         minLength="3"
@@ -160,7 +151,7 @@ function SearchMain({
                       />
                     </div>
                     <div className="button-wrapper mt-4 mt-sm-0">
-                      <Button type="submit" {...button} />
+                      <Button submit label="Cerca" {...searchButton} />
                     </div>
                   </div>
                   {(results.length > 0 || formSubmitted) && (
@@ -237,7 +228,7 @@ function SearchMain({
                             </ListItem>
                           ))}
                         </ul>
-                        {results.length > 4 && !isResultsPage && (
+                        {results.length === maxResults && (
                           <div className="mt-4 ps-4 pt-4 d-block border-top">
                             <strong>
                               <Link

--- a/src/components/search-main/search-main.js
+++ b/src/components/search-main/search-main.js
@@ -1,11 +1,12 @@
-import React, { useState, useRef, useEffect } from "react"
-import { useStaticQuery, graphql, Link } from "gatsby"
-import { useFlexSearch } from "react-use-flexsearch"
+import classNames from "classnames";
+import React, { useState, useRef, useEffect } from "react";
+import { useStaticQuery, graphql, Link } from "gatsby";
+import { useFlexSearch } from "react-use-flexsearch";
 
-import Button from "../button/button"
-import Tag from "../tag/tag"
-import ListItem from "../list-item/list-item"
-import './search-main.scss'
+import Button from "../button/button";
+import Tag from "../tag/tag";
+import ListItem from "../list-item/list-item";
+import "./search-main.scss";
 
 function SearchMain({
   location,
@@ -19,106 +20,132 @@ function SearchMain({
   inputId,
   button,
   suggest,
-  background
+  background,
 }) {
-
-  const [input, setInput] = useState(() => location?.state?.searchTerm)
-  const [searchTerm, setSearchTerm] = useState(() => location?.state?.searchTerm)
-  const [formSubmitted, setFormSubmitted] = useState(() => !!location?.state?.searchTerm)
-  const [storedInput, setStoredInput] = useState(() => location?.state?.searchTerm)
+  const [input, setInput] = useState(() => location?.state?.searchTerm);
+  const [searchTerm, setSearchTerm] = useState(
+    () => location?.state?.searchTerm,
+  );
+  const [formSubmitted, setFormSubmitted] = useState(
+    () => !!location?.state?.searchTerm,
+  );
+  const [storedInput, setStoredInput] = useState(
+    () => location?.state?.searchTerm,
+  );
 
   const iconOpt = {
-    icon: 'sprites.svg#it-file',
-    size: 'sm',
+    icon: "sprites.svg#it-file",
+    size: "sm",
     color: "primary",
-    addonClasses: 'mt-1 flex-shrink-0 me-1 me-md-3'
-  }
+    addonClasses: "mt-1 flex-shrink-0 me-1 me-md-3",
+  };
 
-  const { localSearchPages: { index, store } } = useStaticQuery(graphql`
-     query {
-       localSearchPages {
-         index
-         store
-       }
-     }
-  `)
+  const {
+    localSearchPages: { index, store },
+  } = useStaticQuery(graphql`
+    query {
+      localSearchPages {
+        index
+        store
+      }
+    }
+  `);
 
-  const liveRegionRef = useRef(null)
-  const firstRound = useRef(true)
+  const liveRegionRef = useRef(null);
+  const firstRound = useRef(true);
   useEffect(() => {
     if (firstRound.current) {
-      firstRound.current = false
-      return
+      firstRound.current = false;
+      return;
     }
     if (liveRegionRef.current) {
-      liveRegionRef.current.focus()
+      liveRegionRef.current.focus();
     }
-  }, [storedInput])
+  }, [storedInput]);
 
-  const searchLabelRef = useRef(null)
+  const searchLabelRef = useRef(null);
   useEffect(() => {
     if (searchLabelRef.current && input) {
-      searchLabelRef.current.className = "active"
+      searchLabelRef.current.className = "active";
     }
-  }, [storedInput, input])
+  }, [storedInput, input]);
 
   const search = (term) => {
-    setSearchTerm(term)
-    setFormSubmitted(true)
-    setStoredInput(term)
-  }
+    setSearchTerm(term);
+    setFormSubmitted(true);
+    setStoredInput(term);
+  };
 
   const formSubmit = (ev) => {
     ev.preventDefault();
     search(ev.target.elements.search.value);
-    setFormSubmitted(true)
-    setStoredInput(input)
-  }
+    setFormSubmitted(true);
+    setStoredInput(input);
+  };
 
   const searchOptions = {
-    limit: `${howMany || ''}`,
+    limit: `${howMany || ""}`,
     // if true "fill" the spaces with suggestions, useful for multiple words query XXX
     suggest: useSuggestionEngine,
-  }
+  };
 
-  const results = useFlexSearch(searchTerm, index, store, searchOptions)
+  const results = useFlexSearch(searchTerm, index, store, searchOptions);
 
-  const styles = 'search-main'
-    + `${background ? ` bg-${  background}` : ''}`
+  const styles = classNames("search-main", {
+    [`bg-${background}`]: background,
+  });
 
   return (
     <section className={styles}>
       <div className="container-xxl">
         <div className="row">
           <div className="col-12 g-0">
-            <div className="search-main-content px-3 py-5 px-lg-0 px-lg-5 py-lg-6" role="search">
-              {title || text ?
+            <div
+              className="search-main-content px-3 py-5 px-lg-0 px-lg-5 py-lg-6"
+              role="search"
+            >
+              {title || text ? (
                 <div className="text-container mb-5">
                   {title && <h2>{title}</h2>}
                   {text && <p className="lead">{text}</p>}
                 </div>
-                : null
-              }
-              {suggest && <div className="suggest-wrapper d-lg-flex mb-3">
-                <h3 className="mb-4">{suggest.title}</h3>
-                {suggest.items && <div className="items-wrapper d-flex flex-wrap ms-lg-5">
-                  <ul className="list-inline d-flex flex-wrap">
-                    {suggest.items.map((item, index) => (
-                      <li className="list-item me-3 mb-3" key={index}>
-                        <Button onClick={() => { setInput(item.label); search(item.label); }} type="submit" size="md" btnStyle="outline-secondary">
-                          {item.label}
-                        </Button>
-                      </li>
-                    ))}
-                  </ul>
-                </div>}
-              </div>
-              }
+              ) : null}
+              {suggest && (
+                <div className="suggest-wrapper d-lg-flex mb-3">
+                  <h3 className="mb-4">{suggest.title}</h3>
+                  {suggest.items && (
+                    <div className="items-wrapper d-flex flex-wrap ms-lg-5">
+                      <ul className="list-inline d-flex flex-wrap">
+                        {suggest.items.map((item, index) => (
+                          <li className="list-item me-3 mb-3" key={index}>
+                            <Button
+                              onClick={() => {
+                                setInput(item.label);
+                                search(item.label);
+                              }}
+                              type="submit"
+                              size="md"
+                              btnStyle="outline-secondary"
+                            >
+                              {item.label}
+                            </Button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )}
               <div className="search-form px-3 px-sm-4 pb-4 mb-5 shadow-lg">
                 <form id={formId} onSubmit={formSubmit}>
                   <div className="d-flex flex-column align-items-center flex-sm-row w-100">
                     <div className="form-group mb-0 flex-grow-1 me-sm-4 w-100">
-                      <label ref={searchLabelRef} /* className="active" */ htmlFor={inputId}>{label}</label>
+                      <label
+                        ref={searchLabelRef}
+                        /* className="active" */ htmlFor={inputId}
+                      >
+                        {label}
+                      </label>
                       <input
                         type="search"
                         className="border-search form-control-lg search"
@@ -128,51 +155,103 @@ function SearchMain({
                         autoComplete="off"
                         minLength="3"
                         required
-                        onChange={ev => setInput(ev.target.value)}
-                        value={input || ''}
+                        onChange={(ev) => setInput(ev.target.value)}
+                        value={input || ""}
                       />
                     </div>
                     <div className="button-wrapper mt-4 mt-sm-0">
                       <Button type="submit" {...button} />
                     </div>
                   </div>
-                  {(results.length > 0 || formSubmitted) && <div id="results">
-                    <div className="it-list-wrapper">
-                      <div className="fw-normal text-muted">
-                        <div className="live-region" tabIndex="-1" ref={liveRegionRef}>
-                          {(formSubmitted) && (results.length > 0) &&
-                            <div className="mt-2 px-sm-2 px-md-4 pt-4"><p>Di seguito i migliori risultati per &ldquo;<strong><mark>{storedInput}</mark></strong>&rdquo;:</p></div>
-                          }
-                          {(formSubmitted) && (results.length === 0) &&
-                            <div className="mt-2 px-sm-2 px-md-4 pt-4"><p>Non ci sono risultati utili per &ldquo;<strong><mark>{storedInput}</mark></strong>&rdquo;, possiamo aiutarti in altro modo?</p></div>
-                          }
-                        </div>
-                      </div>
-                      <ul className="it-list mt-4 mt-md-3">
-                        {results.map(result => (
-                          <ListItem url={result.relativePath} key={result.id} iconLeft icon={iconOpt} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
-                            <div className="d-md-flex">
-                              <h3 className="h6 mb-0">
-                                <strong>{result.title}</strong>
-                              </h3>
-                              <div>
-                                {(result.tag !== "undefined") ? <div className="mb-2 mt-1 mb-md-0 mt-md-0"><Tag label={result.tag} addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal" /></div> : null}
-                                {(result.template === 'level1' || result.template === 'community') ? <div className="mb-2 mt-1 mb-md-0 mt-md-0 d-table d-sm-table d-md-inline-block "><Tag label="Panoramica" addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal" /></div> : null}
+                  {(results.length > 0 || formSubmitted) && (
+                    <div id="results">
+                      <div className="it-list-wrapper">
+                        <div className="fw-normal text-muted">
+                          <div
+                            className="live-region"
+                            tabIndex="-1"
+                            ref={liveRegionRef}
+                          >
+                            {formSubmitted && results.length > 0 && (
+                              <div className="mt-2 px-sm-2 px-md-4 pt-4">
+                                <p>
+                                  Di seguito i migliori risultati per &ldquo;
+                                  <strong>
+                                    <mark>{storedInput}</mark>
+                                  </strong>
+                                  &rdquo;:
+                                </p>
                               </div>
-                            </div>
-                            <p className="text-secondary fw-normal d-block mb-3">
-                              {(result.description !== null) ? <small>{result.description}</small> : null}
-                            </p>
-                          </ListItem>
-                        ))}
-                      </ul>
-                      {(results.length > 4 && !isResultsPage) &&
-                        <div className="mt-4 ps-4 pt-4 d-block border-top">
-                          <strong><Link to="/ricerca/" state={{ searchTerm: input }}>Scopri più risultati</Link></strong>
+                            )}
+                            {formSubmitted && results.length === 0 && (
+                              <div className="mt-2 px-sm-2 px-md-4 pt-4">
+                                <p>
+                                  Non ci sono risultati utili per &ldquo;
+                                  <strong>
+                                    <mark>{storedInput}</mark>
+                                  </strong>
+                                  &rdquo;, possiamo aiutarti in altro modo?
+                                </p>
+                              </div>
+                            )}
+                          </div>
                         </div>
-                      }
+                        <ul className="it-list mt-4 mt-md-3">
+                          {results.map((result) => (
+                            <ListItem
+                              url={result.relativePath}
+                              key={result.id}
+                              iconLeft
+                              icon={iconOpt}
+                              addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+                            >
+                              <div className="d-md-flex">
+                                <h3 className="h6 mb-0">
+                                  <strong>{result.title}</strong>
+                                </h3>
+                                <div>
+                                  {result.tag !== "undefined" ? (
+                                    <div className="mb-2 mt-1 mb-md-0 mt-md-0">
+                                      <Tag
+                                        label={result.tag}
+                                        addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal"
+                                      />
+                                    </div>
+                                  ) : null}
+                                  {result.template === "level1" ||
+                                  result.template === "community" ? (
+                                    <div className="mb-2 mt-1 mb-md-0 mt-md-0 d-table d-sm-table d-md-inline-block ">
+                                      <Tag
+                                        label="Panoramica"
+                                        addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal"
+                                      />
+                                    </div>
+                                  ) : null}
+                                </div>
+                              </div>
+                              <p className="text-secondary fw-normal d-block mb-3">
+                                {result.description !== null ? (
+                                  <small>{result.description}</small>
+                                ) : null}
+                              </p>
+                            </ListItem>
+                          ))}
+                        </ul>
+                        {results.length > 4 && !isResultsPage && (
+                          <div className="mt-4 ps-4 pt-4 d-block border-top">
+                            <strong>
+                              <Link
+                                to="/ricerca/"
+                                state={{ searchTerm: input }}
+                              >
+                                Scopri più risultati
+                              </Link>
+                            </strong>
+                          </div>
+                        )}
+                      </div>
                     </div>
-                  </div>}
+                  )}
                 </form>
               </div>
             </div>
@@ -180,7 +259,7 @@ function SearchMain({
         </div>
       </div>
     </section>
-  )
+  );
 }
 
-export default SearchMain
+export default SearchMain;

--- a/src/components/section-editorial/section-editorial.js
+++ b/src/components/section-editorial/section-editorial.js
@@ -1,17 +1,18 @@
-import * as React from "react"
-import './section-editorial.scss'
-import ReactMarkdown from "react-markdown"
-import TextImageCta from "../text-image-cta/text-image-cta"
-import Numbers from "../numbers/numbers"
-import TitleText from "../title-text/title-text"
-import ImgFull from "../img-full/img-full"
-import Highlight from "../highlight/highlight"
-import Card from "../card/card"
-import Kangaroo from "../kangaroo/kangaroo"
-import ImageIcons from "../image-icons/image-icons"
-import Table from "../table/table"
-import Button from "../button/button"
-import ComponentView from "../component-view/component-view"
+import classNames from "classnames";
+import * as React from "react";
+import "./section-editorial.scss";
+import ReactMarkdown from "react-markdown";
+import TextImageCta from "../text-image-cta/text-image-cta";
+import Numbers from "../numbers/numbers";
+import TitleText from "../title-text/title-text";
+import ImgFull from "../img-full/img-full";
+import Highlight from "../highlight/highlight";
+import Card from "../card/card";
+import Kangaroo from "../kangaroo/kangaroo";
+import ImageIcons from "../image-icons/image-icons";
+import Table from "../table/table";
+import Button from "../button/button";
+import ComponentView from "../component-view/component-view";
 
 function SectionEditorial({
   title,
@@ -38,103 +39,128 @@ function SectionEditorial({
     ImgFull,
     ImageIcons,
     Table,
-    ComponentView
-  }
+    ComponentView,
+  };
 
   // heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h2`
-	}
-
-  const container=""
-  + `${fullColumn ? 'fullcolumn-editorial' : ' container-xxl'}`
-
-  let row="row"
-  + `${menu ? ' flex-lg-row-reverse' : ''}`
-
-  let grid
-  if(full) {
-    grid="col-12"
-  }else{
-    grid="col-12 col-md-10 offset-md-1 col-lg-7 offset-lg-1"
-    + `${centered ? ' m-auto' : ''}`
-  }
-  if(full && menu){
-    grid="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-0"
-  }
-  if(fullColumn) {
-    grid=""
-    row=""
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h2`;
   }
 
-  const styles = 'section-editorial'
-	+ `${background ? ` bg-${background}` : ''}`
-  + `${noSpace ? ' py-0' : ''}`
-  + `${background==="dark" ? ' text-white' : ''}`
+  const container = classNames({
+    "fullcolumn-editorial": fullColumn,
+    "container-xxl": !fullColumn,
+  });
+
+  let row = classNames("row", { "flex-lg-row-reverse": menu });
+
+  let grid;
+  if (full) {
+    grid = "col-12";
+  } else {
+    grid = classNames("col-12 col-md-10 offset-md-1 col-lg-7 offset-lg-1", {
+      "m-auto": centered,
+    });
+  }
+  if (full && menu) {
+    grid = "col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-0";
+  }
+  if (fullColumn) {
+    grid = "";
+    row = "";
+  }
+
+  const styles = classNames("section-editorial", {
+    [`bg-${background}`]: background,
+    "py-0": noSpace,
+    "text-white": background === "dark",
+  });
 
   // buttons
-	let ButtonsRender
-	if (buttons) {
-		ButtonsRender = buttons.map((btn,index) => (
-			   <Button key={`button-${index}`} {...btn}/>
-			))
-	}
+  let ButtonsRender;
+  if (buttons) {
+    ButtonsRender = buttons.map((btn, index) => (
+      <Button key={`button-${index}`} {...btn} />
+    ));
+  }
 
   // xxx a11y downgrade if title is not set, quick fix to review asap
   if (!title) {
     // eslint-disable-next-line no-param-reassign
-    id = undefined
+    id = undefined;
   }
 
-  return(
+  return (
     <section className={styles} aria-describedby={id}>
-        <div className={container}>
-          <div className={row}>
-          {menu &&
-              <div className="d-none d-lg-block col-lg-3 offset-lg-1 affix-parent">
-                <div className="sidebar-wrapper my-lg-0 affix-top">
-                  <div className="sidebar-linklist-wrapper">
-                    <div className="link-list-wrapper">
-                      <ul className="link-list">
-                        <li><a className="list-item medium active" href="#"><span>Link lista 1 (attivo)</span></a>
-                        </li>
-                        <li><a className="list-item medium" href="#"><span>Link lista 3</span></a>
-                        </li>
-                        <li><a className="list-item medium" href="#"><span>Link lista 4</span></a>
-                        </li>
-                      </ul>
-                    </div>
+      <div className={container}>
+        <div className={row}>
+          {menu && (
+            <div className="d-none d-lg-block col-lg-3 offset-lg-1 affix-parent">
+              <div className="sidebar-wrapper my-lg-0 affix-top">
+                <div className="sidebar-linklist-wrapper">
+                  <div className="link-list-wrapper">
+                    <ul className="link-list">
+                      <li>
+                        <a className="list-item medium active" href="#">
+                          <span>Link lista 1 (attivo)</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a className="list-item medium" href="#">
+                          <span>Link lista 3</span>
+                        </a>
+                      </li>
+                      <li>
+                        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                        <a className="list-item medium" href="#">
+                          <span>Link lista 4</span>
+                        </a>
+                      </li>
+                    </ul>
                   </div>
                 </div>
               </div>
-            }
-            <div className={grid}>
-              <div className="px-3 p-md-0">
-                {title && <HLevel className={text ? "mb-1" : "mb-0"} id={id}>{title}</HLevel>}
-                {text &&
-                  <div className="text-container mb-5">
-                    <ReactMarkdown>{text}</ReactMarkdown>
-                  </div>
-                }
-								{ButtonsRender && <div className="buttons-wrapper mt-5">{ButtonsRender}</div>}
-                {components?.map((item,index) => {
-                  const Switcher = SwitchComponents[item.name]
+            </div>
+          )}
+          <div className={grid}>
+            <div className="px-3 p-md-0">
+              {title && (
+                <HLevel className={text ? "mb-1" : "mb-0"} id={id}>
+                  {title}
+                </HLevel>
+              )}
+              {text && (
+                <div className="text-container mb-5">
+                  <ReactMarkdown>{text}</ReactMarkdown>
+                </div>
+              )}
+              {ButtonsRender && (
+                <div className="buttons-wrapper mt-5">{ButtonsRender}</div>
+              )}
+              {components?.map((item, index) => {
+                const Switcher = SwitchComponents[item.name];
 
-                  return <Switcher
+                return (
+                  <Switcher
                     key={`switcher-${index}`}
-                    componentViewerData={item.name === "ComponentView" ? componentViewerData : undefined}
+                    componentViewerData={
+                      item.name === "ComponentView"
+                        ? componentViewerData
+                        : undefined
+                    }
                     {...item}
                   />
-                })}
-              </div>
+                );
+              })}
             </div>
           </div>
         </div>
+      </div>
     </section>
-  )
+  );
 }
 
-export default SectionEditorial
+export default SectionEditorial;

--- a/src/components/section-intro/section-intro.js
+++ b/src/components/section-intro/section-intro.js
@@ -1,8 +1,9 @@
-import React from "react"
-import ReactMarkdown from "react-markdown"
-import "./section-intro.scss"
+import classNames from "classnames";
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import "./section-intro.scss";
 
-import ContentCollapse from "../content-collapse/contentCollapse"
+import ContentCollapse from "../content-collapse/contentCollapse";
 
 function SectionIntro({
   id,
@@ -18,32 +19,32 @@ function SectionIntro({
   children,
   isFull,
 }) {
-
-  const styles = 'section-intro py-5'
-	+ `${background ? ` bg-${background}` : ''}`
+  const styles = classNames("section-intro py-5", {
+    [`bg-${background}`]: background,
+  });
 
   // heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h2`
-	}
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h2`;
+  }
 
-  let cols
-  let pad
+  let cols;
+  let pad;
   if (isHome) {
-    cols = "col-12 g-0"
-    pad = "px-3 px-lg-5"
-  }else{
+    cols = "col-12 g-0";
+    pad = "px-3 px-lg-5";
+  } else {
     // cols = "col col-md-10 offset-md-1 col-lg-7"
     // pad= "px-3 px-lg-0"
-    cols = "col-12 col-lg-8 g-0"
-    pad = "px-3 px-lg-5"
+    cols = "col-12 col-lg-8 g-0";
+    pad = "px-3 px-lg-5";
   }
   if (isFull) {
-    cols = "col-12 g-0"
-    pad = "px-3 px-lg-5"
+    cols = "col-12 g-0";
+    pad = "px-3 px-lg-5";
     // cols= "col col-md-10 offset-md-1"
     // pad= "px-3 px-lg-0"
   }
@@ -53,20 +54,29 @@ function SectionIntro({
       <div className="container-xxl">
         <div className="row">
           <div className={cols}>
-              <div className={pad}>
-                {title && <HLevel id={id} className="mb-2">{title}</HLevel>}
-                {subtitle && <p className="lead font-sans-serif">{subtitle}</p>}
-                <ReactMarkdown>{text}</ReactMarkdown>
-                {children}
-                {moreButton && <ContentCollapse label={moreButton} labelClose={moreButtonClose}>
-                  { moreText }
-                </ContentCollapse>}
-              </div>
+            <div className={pad}>
+              {title && (
+                <HLevel id={id} className="mb-2">
+                  {title}
+                </HLevel>
+              )}
+              {subtitle && <p className="lead font-sans-serif">{subtitle}</p>}
+              <ReactMarkdown>{text}</ReactMarkdown>
+              {children}
+              {moreButton && (
+                <ContentCollapse
+                  label={moreButton}
+                  labelClose={moreButtonClose}
+                >
+                  {moreText}
+                </ContentCollapse>
+              )}
+            </div>
           </div>
         </div>
       </div>
     </section>
-  )
+  );
 }
 
-export default SectionIntro
+export default SectionIntro;

--- a/src/components/section/section.js
+++ b/src/components/section/section.js
@@ -1,29 +1,21 @@
-import React from "react"
+import React from "react";
 
-function Section({
-  background,
-  bgImage,
-  whiteText,
-  describedBy,
-  children
-}) {
-  const sectionnStyles = 'section'
-		+ `${background ? ` section-${background}` : ''}`   // muted, primary, neutral
-		+ `${bgImage ? ' section-image' : ''}`      // url
-    + `${whiteText ? ' white-color' : ''}`      // boolean for white text
+function Section({ background, bgImage, whiteText, describedBy, children }) {
+  const sectionnStyles =
+    "section" +
+    `${background ? ` section-${background}` : ""}` + // muted, primary, neutral
+    `${bgImage ? " section-image" : ""}` + // url
+    `${whiteText ? " white-color" : ""}`; // boolean for white text
 
   return (
-
     <section
       className={sectionnStyles}
       aria-describedby={describedBy}
-      style={{backgroundImage: `url(${bgImage})`}}
+      style={{ backgroundImage: `url(${bgImage})` }}
     >
-      <div className="section-content">
-        {children}
-      </div>
+      <div className="section-content">{children}</div>
     </section>
-  )
+  );
 }
 
-export default Section
+export default Section;

--- a/src/components/seo/seo-get-site-metadata.js
+++ b/src/components/seo/seo-get-site-metadata.js
@@ -1,4 +1,4 @@
-import { graphql, useStaticQuery } from "gatsby"
+import { graphql, useStaticQuery } from "gatsby";
 
 // eslint-disable-next-line import/prefer-default-export
 export const SeoGetSiteMetadata = () => {
@@ -20,7 +20,7 @@ export const SeoGetSiteMetadata = () => {
         }
       }
     }
-  `)
+  `);
 
-  return data.site.siteMetadata
-}
+  return data.site.siteMetadata;
+};

--- a/src/components/seo/seo.js
+++ b/src/components/seo/seo.js
@@ -1,72 +1,95 @@
-import React from "react"
-import { SeoGetSiteMetadata } from "./seo-get-site-metadata"
+import React from "react";
+import { SeoGetSiteMetadata } from "./seo-get-site-metadata";
 
 // eslint-disable-next-line import/prefer-default-export
-export function Seo({title, description, image, twitterImage, canonical, pathname, lang, children}) {
-	const {
-		siteName,
-		title: defaultTitle,
-		lang: defaultLang,
-		author,
-		description: defaultDescription,
-		image : defaultImage,
-		twitterImage: defaultTwitterImage,
-		siteUrl,
-		twitterUsername,
-		twitterCreator,
-		twitterSite,
-		themeColor
-	} = SeoGetSiteMetadata()
+export function Seo({
+  title,
+  description,
+  image,
+  twitterImage,
+  canonical,
+  pathname,
+  lang,
+  children,
+}) {
+  const {
+    siteName,
+    title: defaultTitle,
+    lang: defaultLang,
+    author,
+    description: defaultDescription,
+    image: defaultImage,
+    twitterImage: defaultTwitterImage,
+    siteUrl,
+    twitterUsername,
+    twitterCreator,
+    twitterSite,
+    themeColor,
+  } = SeoGetSiteMetadata();
 
-	const seo = {
-		siteName,
-		title: title || defaultTitle,
-		lang: lang || defaultLang,
-		author,
+  const seo = {
+    siteName,
+    title: title || defaultTitle,
+    lang: lang || defaultLang,
+    author,
     canonical,
-		description: description || defaultDescription,
-		image : image || defaultImage,
-		siteUrl,
-		url: `${siteUrl}${pathname || ``}`,
-		twitterUsername,
-		twitterImage: twitterImage || defaultTwitterImage,
-		twitterCreator,
-		twitterSite,
-		themeColor
-	}
-	return (
-		<>
-			<title>{seo.title}</title>
+    description: description || defaultDescription,
+    image: image || defaultImage,
+    siteUrl,
+    url: `${siteUrl}${pathname || ``}`,
+    twitterUsername,
+    twitterImage: twitterImage || defaultTwitterImage,
+    twitterCreator,
+    twitterSite,
+    themeColor,
+  };
+  return (
+    <>
+      <title>{seo.title}</title>
       <meta name="description" content={seo.description} />
-			<meta name="author" content={seo.author} />
+      <meta name="author" content={seo.author} />
       {seo.canonical && <link rel="canonical" href={seo.canonical} />}
       {/* og metatags */}
       <meta property="og:title" content={seo.title} />
-			<meta property="og:locale" content={seo.lang} />
-			<meta property="og:description" content={seo.description} />
-			<meta property="og:url" content={seo.url} />
-			<meta property="og:siteName" content={seo.siteName} />
-			<meta property="og:image" content={seo.image} />
-			<meta property="og:type" content="article" />
-			{/* twitter metatags */}
+      <meta property="og:locale" content={seo.lang} />
+      <meta property="og:description" content={seo.description} />
+      <meta property="og:url" content={seo.url} />
+      <meta property="og:siteName" content={seo.siteName} />
+      <meta property="og:image" content={seo.image} />
+      <meta property="og:type" content="article" />
+      {/* twitter metatags */}
       <meta name="twitter:card" content="summary_large_image" />
-			<meta name="twitter:title" content={seo.title} />
-			<meta name="twitter:image" content={seo.twitterImage} />
-			<meta name="twitter:site" content={seo.twitterSite} />
-			<meta name="twitter:creator" content={seo.twitterCreator} />
-			{/* icons */}
-      <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png"/>
-			<link rel="icon" type="image/png" href="/favicons/favicon-32x32.png" sizes="32x32"/>
-			<link rel="icon" type="image/png" href="/favicons/favicon-16x16.png" sizes="16x16"/>
-			<link rel="manifest" href="/favicons/manifest.json"/>
-			<link rel="mask-icon" href="/favicons/safari-pinned-tab.svg"/>
-			<link rel="shortcut icon" href="/favicons/favicon.ico"/>
-			<meta name="apple-mobile-web-app-title" content={seo.siteName}/>
-			<meta name="application-name" content={seo.siteName}/>
-			<meta name="msapplication-config" content="/favicons/browserconfig.xml"/>
-			{/* theme */}
-      <meta name="theme-color" content={seo.themeColor}/>
-			{children}
-		</>
-	)
+      <meta name="twitter:title" content={seo.title} />
+      <meta name="twitter:image" content={seo.twitterImage} />
+      <meta name="twitter:site" content={seo.twitterSite} />
+      <meta name="twitter:creator" content={seo.twitterCreator} />
+      {/* icons */}
+      <link
+        rel="apple-touch-icon"
+        sizes="180x180"
+        href="/favicons/apple-touch-icon.png"
+      />
+      <link
+        rel="icon"
+        type="image/png"
+        href="/favicons/favicon-32x32.png"
+        sizes="32x32"
+      />
+      <link
+        rel="icon"
+        type="image/png"
+        href="/favicons/favicon-16x16.png"
+        sizes="16x16"
+      />
+      <link rel="manifest" href="/favicons/manifest.json" />
+      <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" />
+      <link rel="shortcut icon" href="/favicons/favicon.ico" />
+      <meta name="apple-mobile-web-app-title" content={seo.siteName} />
+      <meta name="application-name" content={seo.siteName} />
+      <meta name="msapplication-config" content="/favicons/browserconfig.xml" />
+      {/* theme */}
+      <meta name="theme-color" content={seo.themeColor} />
+      {children}
+    </>
+  );
 }

--- a/src/components/share-button/share-button.js
+++ b/src/components/share-button/share-button.js
@@ -1,7 +1,7 @@
-import * as React from "react"
-import PropTypes from "prop-types"
+import * as React from "react";
+import PropTypes from "prop-types";
 
-import Dropdown from "../dropdown/dropdown"
+import Dropdown from "../dropdown/dropdown";
 
 function ShareButton({ title, url, color, small }) {
   // TODO: Compatibility structure that Dropdown understands.
@@ -9,38 +9,38 @@ function ShareButton({ title, url, color, small }) {
   const shareOpts = {
     button: {
       icon: {
-        icon: 'sprites.svg#it-more-items',
-        size: 'sm',
+        icon: "sprites.svg#it-more-items",
+        size: "sm",
         color,
-        addonClasses: 'ms-3'
-      }
+        addonClasses: "ms-3",
+      },
     },
     list: {
-      isShare: true
-    }
-  }
+      isShare: true,
+    },
+  };
 
   if (!small) {
-    shareOpts.button.addonStyle = `btn-share-hero btn-dropdown text-${color} mb-5 mt-lg-4 ms-auto`
-    shareOpts.button.label = 'Condividi'
+    shareOpts.button.addonStyle = `btn-share-hero btn-dropdown text-${color} mb-5 mt-lg-4 ms-auto`;
+    shareOpts.button.label = "Condividi";
   } else {
-    shareOpts.button.addonStyle = 'icon-only-drop'
-    shareOpts.button.ariaLabel = 'Condividi'
+    shareOpts.button.addonStyle = "icon-only-drop";
+    shareOpts.button.ariaLabel = "Condividi";
   }
 
-  return <Dropdown {...shareOpts} shareTitle={title} shareUrl={url} />
+  return <Dropdown {...shareOpts} shareTitle={title} shareUrl={url} />;
 }
 
 ShareButton.defaultProps = {
-  color: 'primary',
+  color: "primary",
   small: false,
-}
+};
 
 ShareButton.propTypes = {
   title: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
-  color: PropTypes.oneOf(['primary', 'white']),
+  color: PropTypes.oneOf(["primary", "white"]),
   small: PropTypes.bool,
-}
+};
 
-export default ShareButton
+export default ShareButton;

--- a/src/components/simple-cta/simple-cta.js
+++ b/src/components/simple-cta/simple-cta.js
@@ -1,30 +1,32 @@
-import * as React from "react"
-import Icon from "../icon/icon"
-import Link from "../link/link"
-import './simple-cta.scss'
+import * as React from "react";
+import Icon from "../icon/icon";
+import Link from "../link/link";
+import "./simple-cta.scss";
 
-function SimpleCta({
-	icon,
-	children,
-	label,
-	url,
-	blank,
-	screenReaderText
-}) {
-	return(
+function SimpleCta({ icon, children, label, url, blank, screenReaderText }) {
+  return (
     <>
-		{ url && <Link className="simple-cta py-1 mb-3" to={url} target={blank ? '_blank' : undefined} rel={blank ? 'noreferrer' : undefined}>
-			<span className="text">{label || children}</span>
-			<span className="visually-hidden">{screenReaderText}</span>
-			<Icon {...icon} />
-		</Link>}
-    { !url && <span className="simple-cta py-1 mb-3">
-			<span className="text">{label || children}</span>
-			<span className="visually-hidden">{screenReaderText}</span>
-			<Icon {...icon} />
-		</span>}
+      {url && (
+        <Link
+          className="simple-cta py-1 mb-3"
+          to={url}
+          target={blank ? "_blank" : undefined}
+          rel={blank ? "noreferrer" : undefined}
+        >
+          <span className="text">{label || children}</span>
+          <span className="visually-hidden">{screenReaderText}</span>
+          <Icon {...icon} />
+        </Link>
+      )}
+      {!url && (
+        <span className="simple-cta py-1 mb-3">
+          <span className="text">{label || children}</span>
+          <span className="visually-hidden">{screenReaderText}</span>
+          <Icon {...icon} />
+        </span>
+      )}
     </>
-	)
+  );
 }
 
-export default SimpleCta
+export default SimpleCta;

--- a/src/components/skiplinks/skiplinks.js
+++ b/src/components/skiplinks/skiplinks.js
@@ -1,22 +1,21 @@
-import React from "react"
+import React from "react";
 
-function Skiplinks({data}) {
-
-  let skiplinksItems
+function Skiplinks({ data }) {
+  let skiplinksItems;
 
   if (data) {
-    skiplinksItems = data.map((item,index) => (
-        <a className="visually-hidden-focusable" key={`skiplink-${index}`} href={item.url}>
-          {item.label}
-        </a>
-      ))
+    skiplinksItems = data.map((item, index) => (
+      <a
+        className="visually-hidden-focusable"
+        key={`skiplink-${index}`}
+        href={item.url}
+      >
+        {item.label}
+      </a>
+    ));
   }
 
-  return (
-    <div className="skiplinks">
-      {skiplinksItems}
-    </div>
-  )
+  return <div className="skiplinks">{skiplinksItems}</div>;
 }
 
-export default Skiplinks
+export default Skiplinks;

--- a/src/components/subscribe/subscribe.js
+++ b/src/components/subscribe/subscribe.js
@@ -1,34 +1,37 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
+import React, { useState } from "react";
+import PropTypes from "prop-types";
 
-import './subscribe.scss';
+import "./subscribe.scss";
 
 const messages = {
   it: {
-    header: 'Le nostre iniziative, direttamente nella tua mail',
-    title: 'Lasciaci la tua email e ti aggiorneremo sulle nostre prossime iniziative',
-    loading: 'Caricamento...',
-    placeholder: 'indirizzo email',
-    errorText: 'Qualcosa è andato storto 😔 Riprova più tardi',
-    successText: 'Ti abbiamo mandato un’email, segui il collegamento per confermare la tua iscrizione',
-    privacyText: 'leggi l’informativa',
+    header: "Le nostre iniziative, direttamente nella tua mail",
+    title:
+      "Lasciaci la tua email e ti aggiorneremo sulle nostre prossime iniziative",
+    loading: "Caricamento...",
+    placeholder: "indirizzo email",
+    errorText: "Qualcosa è andato storto 😔 Riprova più tardi",
+    successText:
+      "Ti abbiamo mandato un’email, segui il collegamento per confermare la tua iscrizione",
+    privacyText: "leggi l’informativa",
   },
   en: {
-    header: 'Our initiatives, right in your email',
-    title: 'Leave us your email address and we’ll keep you posted',
-    loading: 'Loading...',
-    placeholder: 'email address',
-    errorText: 'Something went wrong 😔 Please try again later',
-    successText: 'We sent you an email, follow the link to confirm your subscription',
-    privacyText: 'privacy policy',
+    header: "Our initiatives, right in your email",
+    title: "Leave us your email address and we’ll keep you posted",
+    loading: "Loading...",
+    placeholder: "email address",
+    errorText: "Something went wrong 😔 Please try again later",
+    successText:
+      "We sent you an email, follow the link to confirm your subscription",
+    privacyText: "privacy policy",
   },
 };
 
 const StateClass = Object.freeze({
-  START: { className: '' },
-  LOADING: { className: 'success' },
-  SUCCESS: { className: 'success' },
-  ERROR: { className: 'danger' },
+  START: { className: "" },
+  LOADING: { className: "success" },
+  SUCCESS: { className: "success" },
+  ERROR: { className: "danger" },
 });
 
 function Subscribe({
@@ -41,15 +44,17 @@ function Subscribe({
   lang,
 }) {
   const [state, setState] = useState(StateClass.START);
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState("");
 
   const t = (key) => messages[lang][key];
 
   const onSubmit = async (e) => {
-    const endpoint = 'https://sendportal.developers.italia.it/api/v1/subscribe';
+    const endpoint = "https://sendportal.developers.italia.it/api/v1/subscribe";
     const data = {};
 
-    new FormData(e.target).forEach((value, key) => { data[key] = value });
+    new FormData(e.target).forEach((value, key) => {
+      data[key] = value;
+    });
 
     e.preventDefault();
 
@@ -57,10 +62,10 @@ function Subscribe({
       setState(StateClass.LOADING);
 
       const r = await fetch(endpoint, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
+          Accept: "application/json",
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(data),
       });
@@ -72,57 +77,65 @@ function Subscribe({
       setState(StateClass.ERROR);
       // eslint-disable-next-line no-console
       console.error(`Mailing list subscribe error: ${ex}`);
-      setMessage(t('errorText'));
+      setMessage(t("errorText"));
 
       return;
     }
 
     setState(StateClass.SUCCESS);
-    setMessage(t('successText'));
+    setMessage(t("successText"));
   };
 
   return (
     <div className="subscribe">
-        <form id={idForm} onSubmit={onSubmit}>
-          <div className="form-group mb-0 me-3">
-            <label htmlFor={id} className={`active ${labelClass}`}>{label}</label>
-            <input
-              type="email"
-              className="form-control"
-              required
-              id={id}
-              name="email"
-            />
-            {Object.entries(sendportalArgs).map(([argName, argValue], i) => (
-              <input type="hidden" name={argName} value={argValue} key={i} />
-            ))}
-          </div>
-          <button
-            type="submit"
-            className="btn btn-outline-primary"
-            disabled={state === StateClass.LOADING}
-          >
-            {state === StateClass.LOADING ? (
-              <>
-                <span
-                  className="spinner-border spinner-border-sm me-2" role="status"
-                  aria-hidden="true"
-                />
-                <span className="sr-only">{t('loading')}</span>
-              </>
-            ) : (
-              <span>{button.label}</span>
-            )}
-          </button>
-        </form>
-        <div
-          className={`alert alert-${state.className} bg-light mt-2`}
-          style={{ visibility: state === StateClass.SUCCESS || state === StateClass.ERROR ? 'visible' : 'hidden' }}
-          role="alert"
-        >
-          {message}
+      <form id={idForm} onSubmit={onSubmit}>
+        <div className="form-group mb-0 me-3">
+          <label htmlFor={id} className={`active ${labelClass}`}>
+            {label}
+          </label>
+          <input
+            type="email"
+            className="form-control"
+            required
+            id={id}
+            name="email"
+          />
+          {Object.entries(sendportalArgs).map(([argName, argValue], i) => (
+            <input type="hidden" name={argName} value={argValue} key={i} />
+          ))}
         </div>
+        <button
+          type="submit"
+          className="btn btn-outline-primary"
+          disabled={state === StateClass.LOADING}
+        >
+          {state === StateClass.LOADING ? (
+            <>
+              <span
+                className="spinner-border spinner-border-sm me-2"
+                role="status"
+                aria-hidden="true"
+              />
+              <span className="sr-only">{t("loading")}</span>
+            </>
+          ) : (
+            <span>{button.label}</span>
+          )}
+        </button>
+      </form>
+      <div
+        className={`alert alert-${state.className} bg-light mt-2`}
+        style={{
+          visibility:
+            state === StateClass.SUCCESS || state === StateClass.ERROR
+              ? "visible"
+              : "hidden",
+        }}
+        role="alert"
+      >
+        {message}
       </div>
+    </div>
   );
 }
 
@@ -137,11 +150,11 @@ Subscribe.propTypes = {
 };
 
 Subscribe.defaultProps = {
-  labelClass: '',
-  sendportalArgs: '{}',
-  lang: 'it',
+  labelClass: "",
+  sendportalArgs: "{}",
+  lang: "it",
 };
 
-Subscribe.displayName = 'Subscribe';
+Subscribe.displayName = "Subscribe";
 
-export default Subscribe
+export default Subscribe;

--- a/src/components/tab/tab.js
+++ b/src/components/tab/tab.js
@@ -1,105 +1,168 @@
-import React from "react"
-import "./tab.scss"
-import SectionEditorial from "../section-editorial/section-editorial"
-import ComponentView from "../component-view/component-view"
-import ContentSelect from "../content-select/content-select"
-import ContentSelectItem from "../content-select/components/content-select-item/content-select-item"
+import React from "react";
+import "./tab.scss";
+import SectionEditorial from "../section-editorial/section-editorial";
+import ComponentView from "../component-view/component-view";
+import ContentSelect from "../content-select/content-select";
+import ContentSelectItem from "../content-select/components/content-select-item/content-select-item";
 
-import TabButton from "./tabbutton"
+import TabButton from "./tabbutton";
 
-function Tab({
-  componentSource,
-  tab01,
-  tab02,
-  tab03
-}) {
+function Tab({ componentSource, tab01, tab02, tab03 }) {
   return (
     <div className="tab pt-5 /*pt-lg-6*/">
       <div className="">
-        <ul className="nav nav-tabs nav-tabs-cards auto" id="card-simple" role="tablist">
+        <ul
+          className="nav nav-tabs nav-tabs-cards auto"
+          id="card-simple"
+          role="tablist"
+        >
           <li className="nav-item-filler flex-grow-0 px-3 p-md-0" />
           <li className="nav-item">
-            <TabButton className="nav-link active" id="card-simple1-tab" href="#card-simpletab1" role="tab" aria-controls="card-simpletab1" aria-selected="true">{tab01.title}</TabButton>
+            <TabButton
+              className="nav-link active"
+              id="card-simple1-tab"
+              href="#card-simpletab1"
+              role="tab"
+              aria-controls="card-simpletab1"
+              aria-selected="true"
+            >
+              {tab01.title}
+            </TabButton>
           </li>
           <li className="nav-item">
-            <TabButton className="nav-link" id="card-simple2-tab" href="#card-simpletab2" role="tab" aria-controls="card-simpletab2" aria-selected="false">{tab02.title}</TabButton>
+            <TabButton
+              className="nav-link"
+              id="card-simple2-tab"
+              href="#card-simpletab2"
+              role="tab"
+              aria-controls="card-simpletab2"
+              aria-selected="false"
+            >
+              {tab02.title}
+            </TabButton>
           </li>
           <li className="nav-item">
-            <TabButton className="nav-link" id="card-simple3-tab" href="#card-simpletab3" role="tab" aria-controls="card-simpletab3" aria-selected="false">{tab03.title}</TabButton>
+            <TabButton
+              className="nav-link"
+              id="card-simple3-tab"
+              href="#card-simpletab3"
+              role="tab"
+              aria-controls="card-simpletab3"
+              aria-selected="false"
+            >
+              {tab03.title}
+            </TabButton>
           </li>
           <li className="nav-item-filler px-3 p-md-0" />
         </ul>
       </div>
       <div className="tab-content" id="card-simpleContent">
-        <div className="tab-pane py-5 fade show active" id="card-simpletab1" role="tabpanel" aria-labelledby="card-simple1-tab">
+        <div
+          className="tab-pane py-5 fade show active"
+          id="card-simpletab1"
+          role="tabpanel"
+          aria-labelledby="card-simple1-tab"
+        >
+          {tab01.variants && (
+            <ContentSelect label="Variante" {...tab01.componentVariant}>
+              {tab01.variants.map((v, idx) => (
+                <ContentSelectItem key={`item-${idx}`} name={v.name}>
+                  <ComponentView
+                    variantName={v.name}
+                    source={componentSource}
+                    content={v.content}
+                    idPrefix="use-preview-"
+                    viewerHeight={tab01.componentVariant.viewerHeight}
+                    accordionUrl={tab01.componentVariant.accordionUrl}
+                    accordionOpen={tab01.componentVariant.accordionOpen}
+                    accordionShow={tab01.componentVariant.accordionShow}
+                  />
+                </ContentSelectItem>
+              ))}
+            </ContentSelect>
+          )}
 
-          {tab01.variants && <ContentSelect label="Variante" {...tab01.componentVariant}>
-            {tab01.variants.map((v, idx) => <ContentSelectItem key={`item-${  idx}`} name={v.name}>
-              <ComponentView
-                variantName={v.name}
-                source={componentSource}
-                content={v.content}
-                idPrefix="use-preview-"
-                viewerHeight={tab01.componentVariant.viewerHeight}
-                accordionUrl={tab01.componentVariant.accordionUrl}
-                accordionOpen={tab01.componentVariant.accordionOpen}
-                accordionShow={tab01.componentVariant.accordionShow}
+          {tab01.sectionsEditorial &&
+            tab01.sectionsEditorial.map((section, index) => (
+              <SectionEditorial
+                key={`sectionEditorialTab01-${index}`}
+                {...section}
               />
-            </ContentSelectItem>)}
-          </ContentSelect>}
-
-          {tab01.sectionsEditorial && tab01.sectionsEditorial.map((section, index) => (
-              <SectionEditorial key={`sectionEditorialTab01-${  index}`} {...section} />
             ))}
-
         </div>
-        <div className="tab-pane py-5 fade" id="card-simpletab2" role="tabpanel" aria-labelledby="card-simple2-tab">
+        <div
+          className="tab-pane py-5 fade"
+          id="card-simpletab2"
+          role="tabpanel"
+          aria-labelledby="card-simple2-tab"
+        >
+          {tab02.variants && (
+            <ContentSelect {...tab02.componentVariant}>
+              {tab02.variants.map((v, idx) => (
+                <ContentSelectItem
+                  label="Variante"
+                  key={`item-${idx}`}
+                  name={v.name}
+                >
+                  <ComponentView
+                    variantName={v.name}
+                    source={componentSource}
+                    content={v.content}
+                    idPrefix="des-preview-"
+                    viewerHeight={tab02.componentVariant.viewerHeight}
+                    accordionUrl={tab02.componentVariant.accordionUrl}
+                    accordionOpen={tab02.componentVariant.accordionOpen}
+                    accordionShow={tab02.componentVariant.accordionShow}
+                  />
+                </ContentSelectItem>
+              ))}
+            </ContentSelect>
+          )}
 
-          {tab02.variants && <ContentSelect {...tab02.componentVariant}>
-            {tab02.variants.map((v, idx) => <ContentSelectItem label="Variante" key={`item-${  idx}`} name={v.name}>
-              <ComponentView
-                variantName={v.name}
-                source={componentSource}
-                content={v.content}
-                idPrefix="des-preview-"
-                viewerHeight={tab02.componentVariant.viewerHeight}
-                accordionUrl={tab02.componentVariant.accordionUrl}
-                accordionOpen={tab02.componentVariant.accordionOpen}
-                accordionShow={tab02.componentVariant.accordionShow}
+          {tab02.sectionsEditorial &&
+            tab02.sectionsEditorial.map((section, index) => (
+              <SectionEditorial
+                key={`sectionEditorialTab02-${index}`}
+                {...section}
               />
-            </ContentSelectItem>)}
-          </ContentSelect>}
-
-          {tab02.sectionsEditorial && tab02.sectionsEditorial.map((section, index) => (
-              <SectionEditorial key={`sectionEditorialTab02-${  index}`} {...section} />
             ))}
-
         </div>
-        <div className="tab-pane py-5 fade" id="card-simpletab3" role="tabpanel" aria-labelledby="card-simple3-tab">
+        <div
+          className="tab-pane py-5 fade"
+          id="card-simpletab3"
+          role="tabpanel"
+          aria-labelledby="card-simple3-tab"
+        >
+          {tab03.variants && (
+            <ContentSelect label="Variante" {...tab03.componentVariant}>
+              {tab03.variants.map((v, idx) => (
+                <ContentSelectItem key={`item-${idx}`} name={v.name}>
+                  <ComponentView
+                    variantName={v.name}
+                    source={componentSource}
+                    content={v.content}
+                    idPrefix="dev-preview-"
+                    viewerHeight={tab03.componentVariant.viewerHeight}
+                    accordionUrl={tab03.componentVariant.accordionUrl}
+                    accordionOpen={tab03.componentVariant.accordionOpen}
+                    accordionShow={tab03.componentVariant.accordionShow}
+                  />
+                </ContentSelectItem>
+              ))}
+            </ContentSelect>
+          )}
 
-          {tab03.variants && <ContentSelect label="Variante" {...tab03.componentVariant}>
-            {tab03.variants.map((v, idx) => <ContentSelectItem key={`item-${  idx}`} name={v.name}>
-              <ComponentView
-                variantName={v.name}
-                source={componentSource}
-                content={v.content}
-                idPrefix="dev-preview-"
-                viewerHeight={tab03.componentVariant.viewerHeight}
-                accordionUrl={tab03.componentVariant.accordionUrl}
-                accordionOpen={tab03.componentVariant.accordionOpen}
-                accordionShow={tab03.componentVariant.accordionShow}
+          {tab03.sectionsEditorial &&
+            tab03.sectionsEditorial.map((section, index) => (
+              <SectionEditorial
+                key={`sectionEditorialTab03-${index}`}
+                {...section}
               />
-            </ContentSelectItem>)}
-          </ContentSelect>}
-
-          {tab03.sectionsEditorial && tab03.sectionsEditorial.map((section, index) => (
-              <SectionEditorial key={`sectionEditorialTab03-${  index}`} {...section} />
             ))}
-
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default Tab
+export default Tab;

--- a/src/components/tab/tabbutton.js
+++ b/src/components/tab/tabbutton.js
@@ -1,17 +1,28 @@
-import React, { useEffect } from "react"
+import React, { useEffect } from "react";
 
-import { Tab as TabBI } from "bootstrap-italia"
+import { Tab as TabBI } from "bootstrap-italia";
 
 function TabButton(props) {
-    let instance;
-    useEffect(() => {
-        // eslint-disable-next-line react-hooks/exhaustive-deps, react/destructuring-assignment
-        instance = new TabBI(document.getElementById(props.id))
-    });
-    return (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, react/destructuring-assignment
-        <a {...props} onClick={(e) => {e.preventDefault(); instance.show()}}>{props.children}</a>
-    )
+  let instance;
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps, react/destructuring-assignment
+    instance = new TabBI(document.getElementById(props.id));
+  });
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <a
+      {...props}
+      onClick={(e) => {
+        e.preventDefault();
+        instance.show();
+      }}
+    >
+      {
+        // eslint-disable-next-line react/destructuring-assignment
+        props.children
+      }
+    </a>
+  );
 }
 
-export default TabButton
+export default TabButton;

--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -1,81 +1,75 @@
-import React from "react"
-import ReactMarkdown from "react-markdown"
-import Tag from "../tag/tag"
-import SimpleCta from "../simple-cta/simple-cta"
-import "./table.scss"
+import classNames from "classnames";
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import Tag from "../tag/tag";
+import SimpleCta from "../simple-cta/simple-cta";
+import "./table.scss";
 
-function Table({
-  title,
-  head,
-  rows,
-  addonClasses,
-  responsive,
-  headingLevel
-}) {
+function Table({ title, head, rows, addonClasses, responsive, headingLevel }) {
+  const HLevel = headingLevel ? `h${headingLevel}` : "h3";
+  const tableClasses = classNames("table y-4", addonClasses);
 
-	const HLevel = headingLevel ? `h${headingLevel}` : "h3";
-  const tableClasses = "table y-4"
-    + `${addonClasses ? ` ${addonClasses}` : ''}`
-
-  let headItems
-  let rowItems
-	let CellType
-  let CellScope
+  let headItems;
+  let rowItems;
+  let CellType;
+  let CellScope;
 
   if (head) {
-    headItems = head.map((item,index) => (
-        <th scope="col" key={`th-${index}`}>
-          {item.text}
-          { item.tag && <Tag {...item.tag}/>}
-          </th>
-      ))
+    headItems = head.map((item, index) => (
+      <th scope="col" key={`th-${index}`}>
+        {item.text}
+        {item.tag && <Tag {...item.tag} />}
+      </th>
+    ));
   }
 
   if (rows) {
-    rowItems = rows.map((rowItem,index) => (
-        <tr key={`tr-${index}`}>{
-          rowItem.cols.map((tdItem,index) => {
-            if (tdItem.scope) {
-              CellType = `th`
-              CellScope = 'row'
-            } else {
-              CellType = `td`
-              CellScope = null
-            }
-            const tagsItems = tdItem.tags?.map((item,index) => (
-              <div>
-                <Tag {...item} key={`tag-${index}`}/>
-              </div>
-              ));
-            return(
-              <CellType scope={CellScope} key={`td-${index}`} className={tdItem.addonClasses}>
-                { tdItem.text && <ReactMarkdown>{tdItem.text}</ReactMarkdown>}
-                { tdItem.tags && <div>{tagsItems}</div>}
-                { tdItem.tag && <Tag {...tdItem.tag}/>}
-                { tdItem.simpleCta && <SimpleCta {...tdItem.simpleCta} />}
-              </CellType>
-            )
-          })
-        }</tr>
-      ))
+    rowItems = rows.map((rowItem, index) => (
+      <tr key={`tr-${index}`}>
+        {rowItem.cols.map((tdItem, index) => {
+          if (tdItem.scope) {
+            CellType = `th`;
+            CellScope = "row";
+          } else {
+            CellType = `td`;
+            CellScope = null;
+          }
+          const tagsItems = tdItem.tags?.map((item, index) => (
+            <div>
+              <Tag {...item} key={`tag-${index}`} />
+            </div>
+          ));
+          return (
+            <CellType
+              scope={CellScope}
+              key={`td-${index}`}
+              className={tdItem.addonClasses}
+            >
+              {tdItem.text && <ReactMarkdown>{tdItem.text}</ReactMarkdown>}
+              {tdItem.tags && <div>{tagsItems}</div>}
+              {tdItem.tag && <Tag {...tdItem.tag} />}
+              {tdItem.simpleCta && <SimpleCta {...tdItem.simpleCta} />}
+            </CellType>
+          );
+        })}
+      </tr>
+    ));
   }
 
   return (
     <div className={responsive}>
       {title && <HLevel>{title}</HLevel>}
-      
+
       <table className={tableClasses}>
-        { headItems && <thead>
-          <tr>
-            {headItems}
-          </tr>
-        </thead> }
-        <tbody>
-          {rowItems}
-        </tbody>
+        {headItems && (
+          <thead>
+            <tr>{headItems}</tr>
+          </thead>
+        )}
+        <tbody>{rowItems}</tbody>
       </table>
     </div>
-  )
+  );
 }
 
-export default Table
+export default Table;

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -1,33 +1,29 @@
-import * as React from "react"
-import Link from "../link/link"
-import './tag.scss'
+import classNames from "classnames";
+import * as React from "react";
+import Link from "../link/link";
+import "./tag.scss";
 
-function Tag({
-	url,
-	children,
-	label,
-  addonClasses,
-  screenReaderText
-}) {
-  const styles = "tag"
-    + `${addonClasses ? ` ${addonClasses}` : ''}`
+function Tag({ url, children, label, addonClasses, screenReaderText }) {
+  const styles = classNames("tag", addonClasses);
 
   if (url) {
-    return(
+    return (
       <Link to={url} className={styles}>
-        {screenReaderText && <span className="visually-hidden">{screenReaderText}</span>}
+        {screenReaderText && (
+          <span className="visually-hidden">{screenReaderText}</span>
+        )}
         {label || children}
       </Link>
-    )
+    );
   }
-    return(
-      <span className={styles}>
-         {screenReaderText && <span className="visually-hidden">{screenReaderText}</span>}
-        {label || children}
-      </span>
-    )
-
-
+  return (
+    <span className={styles}>
+      {screenReaderText && (
+        <span className="visually-hidden">{screenReaderText}</span>
+      )}
+      {label || children}
+    </span>
+  );
 }
 
-export default Tag
+export default Tag;

--- a/src/components/test-yaml/test-yaml.js
+++ b/src/components/test-yaml/test-yaml.js
@@ -1,20 +1,16 @@
-import * as React from "react"
-import Section from "../section/section"
+import * as React from "react";
+import Section from "../section/section";
 
-function TestYaml({
-  title,
-  subtitle,
-  text
-}) {
-	return (
-		<div className="test">
-			<Section>
-				<h1>{title}</h1>
+function TestYaml({ title, subtitle, text }) {
+  return (
+    <div className="test">
+      <Section>
+        <h1>{title}</h1>
         <h2>{subtitle}</h2>
         <p>{text}</p>
-			</Section>
-		</div>
-	)
+      </Section>
+    </div>
+  );
 }
 
-export default TestYaml
+export default TestYaml;

--- a/src/components/testimonials/testimonials.js
+++ b/src/components/testimonials/testimonials.js
@@ -1,35 +1,33 @@
-import React from "react"
-import Icon from "../icon/icon"
-import "./testimonials.scss"
+import React from "react";
+import Icon from "../icon/icon";
+import "./testimonials.scss";
 
-function Testimonials({
-    items
-  }) {
+function Testimonials({ items }) {
   return (
     <div className="testimonials pt-5">
       <div className="row justify-content-md-between">
-        {items.map((item,index) => (
-            <div key={`col-${index}`} className="col-12 col-md-5">
-              <div className="testimonial-wrapper d-xl-flex mb-5 mb-lg-0">
-                <div className="icon-zone me-4">
-                  <div className="icon-wrapper d-flex align-items-center justify-content-center">
-                    <Icon {...item.icon} />
-                  </div>
-                </div>
-                <div className="testimonial-text mt-4">
-                  <p className="font-serif lead mb-4">
-                    <em>{item.text}</em>
-                  </p>
-                  <span className="d-flex justify-content-end fw-medium">
-                    <em>— @{item.signature}</em>
-                  </span>
+        {items.map((item, index) => (
+          <div key={`col-${index}`} className="col-12 col-md-5">
+            <div className="testimonial-wrapper d-xl-flex mb-5 mb-lg-0">
+              <div className="icon-zone me-4">
+                <div className="icon-wrapper d-flex align-items-center justify-content-center">
+                  <Icon {...item.icon} />
                 </div>
               </div>
+              <div className="testimonial-text mt-4">
+                <p className="font-serif lead mb-4">
+                  <em>{item.text}</em>
+                </p>
+                <span className="d-flex justify-content-end fw-medium">
+                  <em>— @{item.signature}</em>
+                </span>
+              </div>
             </div>
-          ))}
+          </div>
+        ))}
       </div>
     </div>
-  )
+  );
 }
 
-export default Testimonials
+export default Testimonials;

--- a/src/components/text-image-cta/text-image-cta.js
+++ b/src/components/text-image-cta/text-image-cta.js
@@ -1,10 +1,11 @@
-import React from "react"
-import ReactMarkdown from "react-markdown"
-import SimpleCta from "../simple-cta/simple-cta"
-import "./text-image-cta.scss"
+import classNames from "classnames";
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import SimpleCta from "../simple-cta/simple-cta";
+import "./text-image-cta.scss";
 
-import ImageResponsive from "../image-responsive/image-responsive"
-import ContentCollapse from "../content-collapse/contentCollapse"
+import ImageResponsive from "../image-responsive/image-responsive";
+import ContentCollapse from "../content-collapse/contentCollapse";
 
 function TextImageCta({
   title,
@@ -18,53 +19,68 @@ function TextImageCta({
   noSpace,
   moreButton,
   moreButtonClose,
-  moreText
+  moreText,
 }) {
-
-
   // heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h3`
-	}
-
-  let ctaItems
-
-  if (ctas) {
-    ctaItems = ctas.map((item,index) => (
-        <SimpleCta {...item} key={`cta-${index}`}/>
-      ))
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h3`;
   }
 
-  const styles = "text-image-cta d-flex"
-  + `${noSpace ? ' mb-0' : ' mb-5 /*mb-lg-5*/'}`
-  + `${image && specular ? ' flex-column flex-sm-row' : ''}` 
-  + `${image && !specular ? ' flex-column flex-sm-row-reverse' : ''}` 
-  const imageWrapperStyles = "image-cta w-25 d-flex align-items-start"
-  + `${specular ? ' justify-content-end me-4' : ' justify-content-start ms-sm-4'}`
-  const contentStyles = "content"
-  + `${image ? ' w-75 pt-4 pt-sm-0' : ' w-100'}`
+  let ctaItems;
+
+  if (ctas) {
+    ctaItems = ctas.map((item, index) => (
+      <SimpleCta {...item} key={`cta-${index}`} />
+    ));
+  }
+
+  const styles = classNames("text-image-cta d-flex", {
+    "mb-0": noSpace,
+    "mb-5": !noSpace,
+    "flex-column flex-sm-row": image && specular,
+    "flex-column flex-sm-row-reverse": image && !specular,
+  });
+
+  const imageWrapperStyles = classNames(
+    "image-cta w-25 d-flex align-items-start",
+    {
+      "justify-content-end me-4": specular,
+      "justify-content-start ms-sm-4": !specular,
+    },
+  );
+
+  const contentStyles = classNames("content", {
+    "w-75 pt-4 pt-sm-0": image,
+    "w-100": !image,
+  });
 
   return (
     <div className={styles}>
-      {image &&
+      {image && (
         <div className={imageWrapperStyles}>
-          <ImageResponsive src={image} alt={alt} imgClassName="w-100 img-fluid img-main rounded"/>
+          <ImageResponsive
+            src={image}
+            alt={alt}
+            imgClassName="w-100 img-fluid img-main rounded"
+          />
         </div>
-      }
+      )}
       <div className={contentStyles}>
         {title && <HLevel className="/*mb-3*/">{title}</HLevel>}
         {lead && <p className="lead font-sans-serif">{lead}</p>}
         {text && <ReactMarkdown>{text}</ReactMarkdown>}
-        {moreButton && <ContentCollapse label={moreButton} labelClose={moreButtonClose}>
-                  { moreText }
-                </ContentCollapse>}
+        {moreButton && (
+          <ContentCollapse label={moreButton} labelClose={moreButtonClose}>
+            {moreText}
+          </ContentCollapse>
+        )}
         {ctaItems && <div className="ctas mt-4 d-md-flex">{ctaItems}</div>}
       </div>
     </div>
-  )
+  );
 }
 
-export default TextImageCta
+export default TextImageCta;

--- a/src/components/title-text/title-text.js
+++ b/src/components/title-text/title-text.js
@@ -1,25 +1,20 @@
-import * as React from "react"
-import ReactMarkdown from "react-markdown"
-import "./title-text.scss"
+import classNames from "classnames";
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import "./title-text.scss";
 
-function TitleText({
-  id,
-  title,
-  background,
-  headingLevel,
-  text
-}) {
-
-  const styles = 'title-text py-5 '
-	+ `${background ? ` bg-${background}` : ''}`
+function TitleText({ id, title, background, headingLevel, text }) {
+  const styles = classNames("title-text py-5", {
+    [`bg-${background}`]: background,
+  });
 
   // heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h2`
-	}
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h2`;
+  }
 
   return (
     <div className={styles} aria-labelledby={id}>
@@ -27,16 +22,20 @@ function TitleText({
         <div className="row">
           {/* <div className='col col-md-10 offset-md-1 col-lg-7'>
               <div className="px-3 px-lg-0"> */}
-          <div className ="col-12 col-lg-9 g-0">
+          <div className="col-12 col-lg-9 g-0">
             <div className="px-3 px-lg-5">
-                {title && <HLevel className={text ? "mb-4" : "mb-0"} id={id}>{title}</HLevel>}
-                <ReactMarkdown>{text}</ReactMarkdown>
-              </div>
+              {title && (
+                <HLevel className={text ? "mb-4" : "mb-0"} id={id}>
+                  {title}
+                </HLevel>
+              )}
+              <ReactMarkdown>{text}</ReactMarkdown>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default TitleText
+export default TitleText;

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -1,39 +1,33 @@
-import * as React from "react"
-import { useEffect, useRef } from "react"
-import { Tooltip as BSITooltip } from 'bootstrap-italia'
-import Icon from "../icon/icon"
-import Button from "../button/button"
+import * as React from "react";
+import { useEffect, useRef } from "react";
+import { Tooltip as BSITooltip } from "bootstrap-italia";
+import Icon from "../icon/icon";
+import Button from "../button/button";
 
+function Tooltip({ label, children }) {
+  const ICON_INFO = {
+    icon: "sprites.svg#it-info-circle",
+    size: "sm",
+    color: "primary",
+    addonClasses: "align-middle",
+    ariaLabel: " Informazioni",
+  };
 
+  const tRef = useRef();
 
-function Tooltip({
-		label,
-		children
-	}) {
-
-	const ICON_INFO = {
-		icon: "sprites.svg#it-info-circle",
-		size: "sm",
-		color: "primary",
-		addonClasses: "align-middle",
-		ariaLabel: " Informazioni"
-	}
-
-	const tRef = useRef()
-
-	useEffect(() => {
+  useEffect(() => {
     // eslint-disable-next-line no-new
-		new BSITooltip(tRef.current.children[0])
-	}, [])
+    new BSITooltip(tRef.current.children[0]);
+  }, []);
 
-	return (
-		<span ref={tRef} >
-			<Button addonStyle="btn p-0 shadow-none" title={label}>
-				<Icon {...ICON_INFO}/>
-				{children}
-			</Button>
-		</span>
-	)
+  return (
+    <span ref={tRef}>
+      <Button addonStyle="btn p-0 shadow-none" title={label}>
+        <Icon {...ICON_INFO} />
+        {children}
+      </Button>
+    </span>
+  );
 }
 
-export default Tooltip
+export default Tooltip;

--- a/src/components/topics/topics.js
+++ b/src/components/topics/topics.js
@@ -1,24 +1,17 @@
-import React from "react"
-import Icon from "../icon/icon"
-import Button from "../button/button"
-import Chip from "../chip/chip"
-import "./topics.scss"
+import React from "react";
+import Icon from "../icon/icon";
+import Button from "../button/button";
+import Chip from "../chip/chip";
+import "./topics.scss";
 
-function Topics({
-  title,
-  headingLevel,
-  icon,
-  tags,
-  button
-}) {
-
+function Topics({ title, headingLevel, icon, tags, button }) {
   // heading level
-	let HLevel
-	if (headingLevel) {
-		HLevel = `h${headingLevel}`;
-	} else {
-		HLevel = `h2`
-	}
+  let HLevel;
+  if (headingLevel) {
+    HLevel = `h${headingLevel}`;
+  } else {
+    HLevel = `h2`;
+  }
 
   return (
     <div className="topics py-5">
@@ -27,26 +20,32 @@ function Topics({
           <div className="row">
             <div className="col-12 col-md-8 col-lg-9 d-md-flex align-items-center">
               <div className="icon-wrapper d-none d-lg-block flex-shrink-0 me-5">
-                <Icon {...icon}/>
+                <Icon {...icon} />
               </div>
               <div className="content">
                 <HLevel className="h4 fw-bold mb-2">{title}</HLevel>
-                {tags && <div className="chip-container">
-                  { tags.map((tag,index) => (
-                      <Chip key={`chip-${index}`} label={tag} size="lg" color="primary" />
+                {tags && (
+                  <div className="chip-container">
+                    {tags.map((tag, index) => (
+                      <Chip
+                        key={`chip-${index}`}
+                        label={tag}
+                        size="lg"
+                        color="primary"
+                      />
                     ))}
-                </div>
-              }
+                  </div>
+                )}
               </div>
             </div>
             <div className="col-12 col-md-4 col-lg-3 mt-4 mt-md-5 d-md-flex justify-content-end align-items-start">
-              <Button {...button}/>
+              <Button {...button} />
             </div>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default Topics
+export default Topics;

--- a/src/data/component-viewer.yaml
+++ b/src/data/component-viewer.yaml
@@ -1,18 +1,15 @@
 accordionLabel: "Codice Bootstrap Italia"
 accordionSrLabel: Apri la documentazione del componente sul sito Boostrap Italia
 accordionSrCopyLabel: Copia negli appunti il codice del componente Bootstrap Italia
-viewer: 
+viewer:
   label: "Risoluzione "
   responsiveButtons:
-    - type: button
-      label: "mobile"
+    - label: "mobile"
       addonStyle: btn-me btn-xs btn-outline-secondary small
       ariaLabel: Visualizzazione anteprima mobile 360px
-    - type: button
-      label: "tablet"
+    - label: "tablet"
       addonStyle: btn-me btn-xs btn-outline-secondary small
       ariaLabel: Visualizzazione anteprima tablet 768px
-    - type: button
-      label: "desktop"
+    - label: "desktop"
       addonStyle: btn-xs btn-outline-secondary small
       ariaLabel: Visualizzazione anteprima desktop

--- a/src/data/content/community.yaml
+++ b/src/data/content/community.yaml
@@ -105,8 +105,7 @@ components:
       col4: true
       background: light
       buttons:
-      - type: button
-        btnStyle: primary
+      - btnStyle: primary
         label: Esplora tutti gli eventi
         url: "/community/eventi/"
         addonStyle: d-block
@@ -203,8 +202,7 @@ components:
       col4: false
       background: null
       buttons:
-      - type: button
-        btnStyle: primary
+      - btnStyle: primary
         label: Esplora tutte le notizie
         addonStyle: d-block
         url: "/community/notizie/"
@@ -274,14 +272,12 @@ components:
       col4: false
       background: light
       buttons:
-      - type: button
-        btnStyle: primary
+      - btnStyle: primary
         label: Esplora tutti gli approfondimenti
         addonStyle: me-3 d-block
         url: "#"
         disabled: true
-      - type: button
-        btnStyle: outline-primary
+      - btnStyle: outline-primary
         label: Vai al Medium di Designers Italia
         url: https://medium.com/designers-italia
         blank: true
@@ -360,8 +356,7 @@ components:
     #   col4: true
     #   background: null
     #   buttons:
-    #   - type: button
-    #     btnStyle: primary
+    #   - btnStyle: primary
     #     label: Esplora tutti i media
     #     addonStyle: d-block
     #     disabled: true

--- a/src/data/content/design-system/come-contribuire.yaml
+++ b/src/data/content/design-system/come-contribuire.yaml
@@ -89,7 +89,6 @@ components:
     # idInput: fundamentCardsInput # < XXX ENABLE TO ENABLE FILTER INPUT FORM ON FRONT END
     col2: true
     # button:
-    #   type: button
     #   btnStyle: outline-secondary justify-content-center w-100
     #   label: Filtra
     #   iconRight: true

--- a/src/data/content/design-system/come-contribuire.yaml
+++ b/src/data/content/design-system/come-contribuire.yaml
@@ -4,7 +4,7 @@
 metadata:
   template:
     name: design-system-index
-    
+
 seo:
   name: Panoramica come contribuire
   description: Scopri i passi da seguire per contribuire al design system del Paese
@@ -66,7 +66,7 @@ components:
         size: sm
       text: In breve
     text: |
-      Partecipa all'evoluzione del design system dedicato alla pubblica amministrazione italiana. Offri il tuo contributo per migliorare, accrescere e far evolvere la qualità della documentazione e delle risorse di design e sviluppo dedicate ai siti e i servizi digitali delle PA. 
+      Partecipa all'evoluzione del design system dedicato alla pubblica amministrazione italiana. Offri il tuo contributo per migliorare, accrescere e far evolvere la qualità della documentazione e delle risorse di design e sviluppo dedicate ai siti e i servizi digitali delle PA.
     kangaroo:
       id: kangarooHero
       noPadding: true

--- a/src/data/content/design-system/come-iniziare.yaml
+++ b/src/data/content/design-system/come-iniziare.yaml
@@ -66,7 +66,6 @@ components:
     # idInput: fundamentCardsInput # < XXX ENABLE TO ENABLE FILTER INPUT FORM ON FRONT END
     col2: true
     # button:
-    #   type: button
     #   btnStyle: outline-secondary justify-content-center w-100
     #   label: Filtra
     #   iconRight: true

--- a/src/data/content/design-system/componenti.yaml
+++ b/src/data/content/design-system/componenti.yaml
@@ -68,7 +68,6 @@ components:
     # idInput: componentCardsInput
     col2: false
     # button:
-    #   type: button
     #   btnStyle: outline-secondary justify-content-center w-100
     #   label: Filtra
     #   iconRight: true

--- a/src/data/content/design-system/fondamenti.yaml
+++ b/src/data/content/design-system/fondamenti.yaml
@@ -67,7 +67,6 @@ components:
     # idInput: fundamentCardsInput # < XXX ENABLE TO ENABLE FILTER INPUT FORM ON FRONT END
     col2: true
     # button:
-    #   type: button
     #   btnStyle: outline-secondary justify-content-center w-100
     #   label: Filtra
     #   iconRight: true

--- a/src/data/content/index.yaml
+++ b/src/data/content/index.yaml
@@ -65,26 +65,8 @@ components:
     fullImg: false
 
   searchMain:
-    disabled: true
-    isResultsPage: false
-    useSuggestionEngine: true
-    background: light
     title: Da dove vuoi iniziare?
-    text: "" # "Questo è un segnaposto, presto qui a disposizione l’inizio della navigazione personalizzata"
-    formId: searchForm
-    label: Cerca
-    inputId: searchInput
-    inputName: search
-    howMany: 5
-    button:
-      label: Cerca
-      type: #submit
-      btnStyle: primary
-      iconRight: true
-      icon:
-        icon: sprites.svg#it-search
-        color: #white
-        addonClasses: ms-1 icon-search
+    maxResults: 5
     suggest:
       title: "Ti suggeriamo:"
       items:
@@ -220,13 +202,11 @@ components:
     nopadtop: true
     hasCustomCols: true
     buttons:
-    - type: button
-      btnStyle: primary
+    - btnStyle: primary
       label: Esplora cosa accade nella community
       url: "community/"
       addonStyle: me-3 d-block
-    # - type: button
-    #   btnStyle: outline-primary
+    # - btnStyle: outline-primary
     #   label: Vai al Medium di Designers Italia
     #   icon:
     #     icon: sprites.svg#it-external-link

--- a/src/data/content/norme-e-riferimenti.yaml
+++ b/src/data/content/norme-e-riferimenti.yaml
@@ -217,13 +217,11 @@ components:
     background: null
     col4: false # FALSE notizie + Medium | TRUE eventi + media
     buttons:
-      # - type: button
-      #   btnStyle: primary
+      # - btnStyle: primary
       #   label: Esplora tutti gli approfondimenti #C
       #   url: "#" #M
       #   addonStyle: me-3 d-block
-      - type: button
-        btnStyle: outline-primary
+      - btnStyle: outline-primary
         label: Vai al Medium di Designers Italia #C
         url: https://medium.com/designers-italia #M
         blank: true

--- a/src/data/content/ricerca.yaml
+++ b/src/data/content/ricerca.yaml
@@ -42,23 +42,4 @@ components:
     subtitle: "Un vasto catalogo di conoscenza e strumenti per creare i servizi digitali della Pubblica Amministrazione."
 
   searchMain:
-    disabled: true
     isResultsPage: true
-    useSuggestionEngine: false
-    background: light
-    # title: Da dove vuoi iniziare?
-    text: "" # "Questo è un segnaposto, presto qui a disposizione l’inizio della navigazione personalizzata"
-    formId: searchForm
-    label: Cerca
-    inputId: searchInput
-    inputName: search
-    # howMany: 2
-    button:
-      label: Cerca
-      type: #submit
-      btnStyle: primary
-      iconRight: true
-      icon:
-        icon: sprites.svg#it-search
-        color: #white
-        addonClasses: ms-1 icon-search

--- a/src/js/globals.js
+++ b/src/js/globals.js
@@ -1,3 +1,3 @@
 if (typeof document !== "undefined") {
-  window.__PUBLIC_PATH__ = '/fonts'
+  window.__PUBLIC_PATH__ = "/fonts";
 }

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,15 +1,15 @@
-import * as React from "react"
+import * as React from "react";
 
-import Button from "../components/button/button"
-import ImageResponsive from "../components/image-responsive/image-responsive"
+import Button from "../components/button/button";
+import ImageResponsive from "../components/image-responsive/image-responsive";
 
-import Template from "../templates/base"
+import Template from "../templates/base";
 
-import "../scss/404.scss"
+import "../scss/404.scss";
 
 const animate = (ev) => {
-  ev.target.classList.add("animate")
-}
+  ev.target.classList.add("animate");
+};
 
 function NotFoundPage() {
   return (
@@ -29,16 +29,16 @@ function NotFoundPage() {
             <div className="col-lg-7 col-12 hero">
               <h1>Un imprevisto può capitare</h1>
               <div className="lead mb-4">
-                <p>
-                  Non abbiamo trovato la pagina che cercavi.
-                </p>
+                <p>Non abbiamo trovato la pagina che cercavi.</p>
 
                 <p className="pb-3">
-                  Verifica che l’indirizzo sia corretto oppure torna all’inizio per
-                  esplorare altri contenuti.
+                  Verifica che l’indirizzo sia corretto oppure torna all’inizio
+                  per esplorare altri contenuti.
                 </p>
                 <div className="buttons-wrapper mt-5 d-grid d-md-block">
-                  <Button btnStyle="btn btn-primary mb-0" url="/"><strong>Vai all’inizio</strong></Button>
+                  <Button btnStyle="btn btn-primary mb-0" url="/">
+                    <strong>Vai all’inizio</strong>
+                  </Button>
                 </div>
               </div>
             </div>
@@ -46,11 +46,11 @@ function NotFoundPage() {
         </div>
       </section>
     </Template>
-  )
+  );
 }
 
-export default NotFoundPage
+export default NotFoundPage;
 
 export function Head() {
-  return <title>Un imprevisto può capitare - Designers Italia</title>
+  return <title>Un imprevisto può capitare - Designers Italia</title>;
 }

--- a/src/pages/{content.relativePath}.js
+++ b/src/pages/{content.relativePath}.js
@@ -1,49 +1,57 @@
-import * as React from "react"
-import { graphql } from "gatsby"
+import * as React from "react";
+import { graphql } from "gatsby";
 
-import TemplateBase from "../templates/base"
-import TemplateArchiveAllTags from "../templates/archive-all-tags"
-import TemplateArchiveDSTags from "../templates/archive-ds-tags"
-import TemplateArchiveNews from "../templates/archive-news"
-import TemplateArchiveEvents from "../templates/archive-events"
-import TemplateDSComponent from "../templates/design-system-component"
-import TemplateDSIndex from "../templates/design-system-index"
-import TemplateHome from "../templates/home"
-import TemplateSearchResults from "../templates/search-results"
-import TemplateLV1Community from "../templates/level-1-community"
-import TemplateLV1 from "../templates/level-1"
-import TemplateLV2 from "../templates/level-2"
-import TemplateLV3 from "../templates/level-3"
-import TemplateLV4 from "../templates/level-4"
+import TemplateBase from "../templates/base";
+import TemplateArchiveAllTags from "../templates/archive-all-tags";
+import TemplateArchiveDSTags from "../templates/archive-ds-tags";
+import TemplateArchiveNews from "../templates/archive-news";
+import TemplateArchiveEvents from "../templates/archive-events";
+import TemplateDSComponent from "../templates/design-system-component";
+import TemplateDSIndex from "../templates/design-system-index";
+import TemplateHome from "../templates/home";
+import TemplateSearchResults from "../templates/search-results";
+import TemplateLV1Community from "../templates/level-1-community";
+import TemplateLV1 from "../templates/level-1";
+import TemplateLV2 from "../templates/level-2";
+import TemplateLV3 from "../templates/level-3";
+import TemplateLV4 from "../templates/level-4";
 
-import { Seo } from "../components/seo/seo"
+import { Seo } from "../components/seo/seo";
 
 const TEMPLATES = {
-  'archive-news' : TemplateArchiveNews,
-  'archive-all-tags' : TemplateArchiveAllTags,
-  'archive-ds-tags' : TemplateArchiveDSTags,
-  'archive-events' : TemplateArchiveEvents,
-  'community' : TemplateLV1Community,
-  'level1' : TemplateLV1,
-  'level2' : TemplateLV2,
-  'level3' : TemplateLV3,
-  'level4' : TemplateLV4,
-  'base' : TemplateBase,
-  'home' : TemplateHome,
-  'search-results' : TemplateSearchResults,
-  'design-system-index' : TemplateDSIndex,
-  'design-system-component' : TemplateDSComponent
-}
+  "archive-news": TemplateArchiveNews,
+  "archive-all-tags": TemplateArchiveAllTags,
+  "archive-ds-tags": TemplateArchiveDSTags,
+  "archive-events": TemplateArchiveEvents,
+  community: TemplateLV1Community,
+  level1: TemplateLV1,
+  level2: TemplateLV2,
+  level3: TemplateLV3,
+  level4: TemplateLV4,
+  base: TemplateBase,
+  home: TemplateHome,
+  "search-results": TemplateSearchResults,
+  "design-system-index": TemplateDSIndex,
+  "design-system-component": TemplateDSComponent,
+};
 
 function Page({ pageContext, location, data: { content } }) {
-  const Template = content.metadata.template ? TEMPLATES[content.metadata.template.name] : TemplateBase
-  const lastModified = content?.parent?.fields?.gitLogLatestDate || new Date(0).toISOString()
+  const Template = content.metadata.template
+    ? TEMPLATES[content.metadata.template.name]
+    : TemplateBase;
+  const lastModified =
+    content?.parent?.fields?.gitLogLatestDate || new Date(0).toISOString();
 
-  return(
-    <Template Pagedata={content} pageContext={pageContext} location={location} lastModified={lastModified}>
+  return (
+    <Template
+      Pagedata={content}
+      pageContext={pageContext}
+      location={location}
+      lastModified={lastModified}
+    >
       {/* place extra components / HTML here */}
     </Template>
-  )
+  );
 }
 
 export const query = graphql`
@@ -362,13 +370,13 @@ export const query = graphql`
         #  background
         #  specular
         #  subtitle
-          # buttons {
-          #  label
-          #  btnStyle
-          #  url
-          #  addonStyle
-          #  # disabled
-          #}
+        # buttons {
+        #  label
+        #  btnStyle
+        #  url
+        #  addonStyle
+        #  # disabled
+        #}
         #}
         searchMain {
           disabled
@@ -871,16 +879,18 @@ export const query = graphql`
       }
     }
   }
-`
-export default Page
+`;
+export default Page;
 
 export function Head({ data: { content } }) {
-  return <Seo
-    title = {content.seo.name}
-    description = {content.seo.description}
-    image = {content.seo.image}
-    twitterImage = {content.seo.twitterImage}
-    pathname = {content.seo.pathname}
-    canonical = {content.seo.canonical}
-   />
+  return (
+    <Seo
+      title={content.seo.name}
+      description={content.seo.description}
+      image={content.seo.image}
+      twitterImage={content.seo.twitterImage}
+      pathname={content.seo.pathname}
+      canonical={content.seo.canonical}
+    />
+  );
 }

--- a/src/pages/{content.relativePath}.js
+++ b/src/pages/{content.relativePath}.js
@@ -253,7 +253,6 @@ export const query = graphql`
           col4
           background
           buttons {
-            type
             btnStyle
             label
             addonStyle
@@ -379,28 +378,8 @@ export const query = graphql`
         #}
         #}
         searchMain {
-          disabled
-          isResultsPage
-          useSuggestionEngine
-          background
           title
-          text
-          formId
-          label
-          inputId
-          inputName
-          howMany
-          button {
-            label
-            # type
-            btnStyle
-            iconRight
-            icon {
-              icon
-              # color
-              addonClasses
-            }
-          }
+          maxResults
           suggest {
             title
             items {
@@ -467,7 +446,6 @@ export const query = graphql`
           }
           headingLevel
           buttons {
-            type
             btnStyle
             label
             url
@@ -514,7 +492,6 @@ export const query = graphql`
           nopadtop
           hasCustomCols
           buttons {
-            type
             btnStyle
             label
             url

--- a/src/templates/archive-all-tags.js
+++ b/src/templates/archive-all-tags.js
@@ -1,61 +1,77 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import ListArchiveAllTags from "../components/list-archive-all-tags/list-archive-all-tags"
+import ListArchiveAllTags from "../components/list-archive-all-tags/list-archive-all-tags";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
 
-import Hero from "../components/hero/hero"
-import ImageIcons from "../components/image-icons/image-icons"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import ImageIcons from "../components/image-icons/image-icons";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
-
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page} />
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />
-        {Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
-        {Pagedata.components.sectionsEditorial && Pagedata.components.sectionsEditorial.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial-${index}`} {...section}/>
+        <Hero
+          {...Pagedata.components.hero}
+          pageContext={pageContext}
+          {...Pagedata.seo}
+        />
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
+        {Pagedata.components.sectionsEditorial &&
+          Pagedata.components.sectionsEditorial.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial-${index}`} {...section} />
           ))}
-        {Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} />}
-        {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
+        {Pagedata.components.sectionsEditorial2 &&
+          Pagedata.components.sectionsEditorial2.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial2-${index}`} {...section} />
           ))}
         {children}
-        
-       <ListArchiveAllTags />
-        
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
+
+        <ListArchiveAllTags />
+
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
         {Pagedata.navPreFooter && <NavPreFooter {...Pagedata.navPreFooter} />}
-        <Feedback/>
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -66,7 +82,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/archive-ds-tags.js
+++ b/src/templates/archive-ds-tags.js
@@ -1,61 +1,77 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import ListArchiveDSTags from "../components/list-archive-ds-tags/list-archive-ds-tags"
+import ListArchiveDSTags from "../components/list-archive-ds-tags/list-archive-ds-tags";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
 
-import Hero from "../components/hero/hero"
-import ImageIcons from "../components/image-icons/image-icons"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import ImageIcons from "../components/image-icons/image-icons";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
-
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page} />
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />
-        {Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
-        {Pagedata.components.sectionsEditorial && Pagedata.components.sectionsEditorial.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial-${index}`} {...section}/>
+        <Hero
+          {...Pagedata.components.hero}
+          pageContext={pageContext}
+          {...Pagedata.seo}
+        />
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
+        {Pagedata.components.sectionsEditorial &&
+          Pagedata.components.sectionsEditorial.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial-${index}`} {...section} />
           ))}
-        {Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} />}
-        {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
+        {Pagedata.components.sectionsEditorial2 &&
+          Pagedata.components.sectionsEditorial2.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial2-${index}`} {...section} />
           ))}
         {children}
-        
-       <ListArchiveDSTags />
-        
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
+
+        <ListArchiveDSTags />
+
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
         {Pagedata.navPreFooter && <NavPreFooter {...Pagedata.navPreFooter} />}
-        <Feedback/>
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -66,7 +82,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/archive-events.js
+++ b/src/templates/archive-events.js
@@ -1,61 +1,77 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import ListArchiveEvents from "../components/list-archive-events/list-archive-events"
+import ListArchiveEvents from "../components/list-archive-events/list-archive-events";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
 
-import Hero from "../components/hero/hero"
-import ImageIcons from "../components/image-icons/image-icons"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import ImageIcons from "../components/image-icons/image-icons";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
-
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page} />
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />
-        {Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
-        {Pagedata.components.sectionsEditorial && Pagedata.components.sectionsEditorial.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial-${index}`} {...section}/>
+        <Hero
+          {...Pagedata.components.hero}
+          pageContext={pageContext}
+          {...Pagedata.seo}
+        />
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
+        {Pagedata.components.sectionsEditorial &&
+          Pagedata.components.sectionsEditorial.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial-${index}`} {...section} />
           ))}
-        {Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} />}
-        {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
+        {Pagedata.components.sectionsEditorial2 &&
+          Pagedata.components.sectionsEditorial2.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial2-${index}`} {...section} />
           ))}
         {children}
-        
-       <ListArchiveEvents />
-        
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
+
+        <ListArchiveEvents />
+
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
         {Pagedata.navPreFooter && <NavPreFooter {...Pagedata.navPreFooter} />}
-        <Feedback/>
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -66,7 +82,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/archive-news.js
+++ b/src/templates/archive-news.js
@@ -1,61 +1,77 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import ListArchiveNews from "../components/list-archive-news/list-archive-news"
+import ListArchiveNews from "../components/list-archive-news/list-archive-news";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
 
-import Hero from "../components/hero/hero"
-import ImageIcons from "../components/image-icons/image-icons"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import ImageIcons from "../components/image-icons/image-icons";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
-
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page} />
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />
-        {Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
-        {Pagedata.components.sectionsEditorial && Pagedata.components.sectionsEditorial.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial-${index}`} {...section}/>
+        <Hero
+          {...Pagedata.components.hero}
+          pageContext={pageContext}
+          {...Pagedata.seo}
+        />
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
+        {Pagedata.components.sectionsEditorial &&
+          Pagedata.components.sectionsEditorial.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial-${index}`} {...section} />
           ))}
-        {Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} />}
-        {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
+        {Pagedata.components.sectionsEditorial2 &&
+          Pagedata.components.sectionsEditorial2.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial2-${index}`} {...section} />
           ))}
         {children}
-        
-       <ListArchiveNews />
-        
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
+
+        <ListArchiveNews />
+
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
         {Pagedata.navPreFooter && <NavPreFooter {...Pagedata.navPreFooter} />}
-        <Feedback/>
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -66,7 +82,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/base.js
+++ b/src/templates/base.js
@@ -1,33 +1,32 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-
-function Template({children, Pagedata, location, pageContext, lastModified}) {
+function Template({ children, Pagedata, location, pageContext, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
           <HeaderNav data={HeaderData.navbar} />
         </NavWrapper>
       </Header>
@@ -35,8 +34,15 @@ function Template({children, Pagedata, location, pageContext, lastModified}) {
       <main id="main">
         {children}
         {/* {Pagedata.lastUpdate ? <LastUpdate {...Pagedata.lastUpdate} /> : null } */}
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
-        <Feedback/>
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -47,7 +53,7 @@ function Template({children, Pagedata, location, pageContext, lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/design-system-component.js
+++ b/src/templates/design-system-component.js
@@ -1,70 +1,87 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import Tab from "../components/tab/tab"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import Tab from "../components/tab/tab";
 
-import NavSidebar from "../components/nav-sidebar/nav-sidebar"
-import Hero from "../components/hero/hero"
+import NavSidebar from "../components/nav-sidebar/nav-sidebar";
+import Hero from "../components/hero/hero";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
-import dsNav from "../data/dsnav.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
+import dsNav from "../data/dsnav.yaml";
 
-import viewerData from "../data/component-viewer.yaml"
+import viewerData from "../data/component-viewer.yaml";
 
-
-function Template({Pagedata,pageContext,location, lastModified}) {
+function Template({ Pagedata, pageContext, location, lastModified }) {
   if (!Pagedata.metadata.json) {
-    throw new Error('json key is required for design-system-component!');
+    throw new Error("json key is required for design-system-component!");
   }
   // eslint-disable-next-line global-require, import/no-dynamic-require
-  const variantMock = require(`../data/components_json/${Pagedata.metadata.json}`)
+  const variantMock = require(
+    `../data/components_json/${Pagedata.metadata.json}`,
+  );
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.title}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.title} />
         </NavWrapper>
       </Header>
       <div className="bg-light">
         <div className="container-xxl">
           <div className="row design-system">
-            <NavSidebar page={Pagedata.components.hero.title} {...dsNav}/>
-            <main id="main" className="col-12 col-lg-9 px-lg-0 content-column bg-white">
-              { Pagedata.components.hero && <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />}
+            <NavSidebar page={Pagedata.components.hero.title} {...dsNav} />
+            <main
+              id="main"
+              className="col-12 col-lg-9 px-lg-0 content-column bg-white"
+            >
+              {Pagedata.components.hero && (
+                <Hero
+                  {...Pagedata.components.hero}
+                  pageContext={pageContext}
+                  {...Pagedata.seo}
+                />
+              )}
               <Tab
                 viewerData={viewerData}
                 componentSource={Pagedata.metadata.json.replace(".json", "")}
-                tab01={({ ...Pagedata.tabs[0], variants: variantMock})}
+                tab01={{ ...Pagedata.tabs[0], variants: variantMock }}
                 tab02={Pagedata.tabs[1]}
-                tab03={({ ...Pagedata.tabs[2], variants: variantMock})}
+                tab03={{ ...Pagedata.tabs[2], variants: variantMock }}
               />
-              {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
+              {lastModified && (
+                <LastUpdate
+                  lastModified={lastModified}
+                  {...Pagedata.lastUpdate}
+                  {...location}
+                  {...pageContext}
+                />
+              )}
             </main>
           </div>
         </div>
 
-        <Feedback/>
+        <Feedback />
       </div>
       <Footer {...FooterData.footer} />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/design-system-index-components-tags.js
+++ b/src/templates/design-system-index-components-tags.js
@@ -1,55 +1,58 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import { graphql } from "gatsby"
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
+import { graphql } from "gatsby";
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
 
-import NavSidebar from "../components/nav-sidebar/nav-sidebar"
-import Hero from "../components/hero/hero"
+import NavSidebar from "../components/nav-sidebar/nav-sidebar";
+import Hero from "../components/hero/hero";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import TagPageData from "../data/tag.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
-import dsNav from "../data/dsnav.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import TagPageData from "../data/tag.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
+import dsNav from "../data/dsnav.yaml";
 
-import Link from "../components/link/link"
-import ListItem from "../components/list-item/list-item"
-import ListArchiveDSTags from "../components/list-archive-ds-tags/list-archive-ds-tags"
+import Link from "../components/link/link";
+import ListItem from "../components/list-item/list-item";
+import ListArchiveDSTags from "../components/list-archive-ds-tags/list-archive-ds-tags";
 
-import { Seo } from "../components/seo/seo"
+import { Seo } from "../components/seo/seo";
 
 function TagsDesignSystem({ children, pageContext, location, data }) {
-  const lastModified = data.content?.parent?.fields?.gitLogLatestDate || new Date(0).toISOString()
+  const lastModified =
+    data.content?.parent?.fields?.gitLogLatestDate || new Date(0).toISOString();
 
-  const { tag } = pageContext
-  const { edges, totalCount } = data.allContentDesignSystemByTag
-  const tagHeader = `Esplora ${totalCount} component${totalCount === 1 ? "e" : "i"} utili`
+  const { tag } = pageContext;
+  const { edges, totalCount } = data.allContentDesignSystemByTag;
+  const tagHeader = `Esplora ${totalCount} component${
+    totalCount === 1 ? "e" : "i"
+  } utili`;
 
   const iconOpt = {
-    icon: 'sprites.svg#it-file',
-    size: 'sm',
+    icon: "sprites.svg#it-file",
+    size: "sm",
     color: "primary",
-    addonClasses: 'mt-1 flex-shrink-0 me-1 me-md-3'
-  }
+    addonClasses: "mt-1 flex-shrink-0 me-1 me-md-3",
+  };
 
-  const container = "container-xxl"
-  const row = "row"
+  const container = "container-xxl";
+  const row = "row";
 
-  const styles = 'section-editorial'
+  const styles = "section-editorial";
 
-  const showTags = true
+  const showTags = true;
 
   return (
     <div id="app">
@@ -66,8 +69,18 @@ function TagsDesignSystem({ children, pageContext, location, data }) {
         <div className="container-xxl">
           <div className="row design-system">
             <NavSidebar page="Panoramica componenti" {...dsNav} />
-            <main id="main" className="col-12 col-lg-9 px-lg-0 content-column bg-white">
-              <Hero {...TagPageData.components.hero} title={tag} subtitle={`Tutti i componenti del design system utili per "${tag}"`} crumbLabel={tag} pageContext={pageContext} {...TagPageData.seo} />
+            <main
+              id="main"
+              className="col-12 col-lg-9 px-lg-0 content-column bg-white"
+            >
+              <Hero
+                {...TagPageData.components.hero}
+                title={tag}
+                subtitle={`Tutti i componenti del design system utili per "${tag}"`}
+                crumbLabel={tag}
+                pageContext={pageContext}
+                {...TagPageData.seo}
+              />
 
               {/* { Pagedata.components.filterCards && <FilterCards {...Pagedata.components.filterCards}/>} */}
 
@@ -76,16 +89,27 @@ function TagsDesignSystem({ children, pageContext, location, data }) {
                   <div className={row}>
                     <div className="col-12 g-0">
                       <div className="px-3 px-lg-0 px-lg-5">
-                        <h2 className="border-bottom pb-4 w-100" id="archive-list-title">{tagHeader}</h2>
+                        <h2
+                          className="border-bottom pb-4 w-100"
+                          id="archive-list-title"
+                        >
+                          {tagHeader}
+                        </h2>
                         <div className="it-list-wrapper">
                           <ul className="it-list mt-4 mt-md-3">
                             {edges.map(({ node }) => {
-                              const { id } = node
-                              const { pathname } = node.seo
-                              const title = node.components?.hero?.title
-                              const { description } = node.seo
+                              const { id } = node;
+                              const { pathname } = node.seo;
+                              const title = node.components?.hero?.title;
+                              const { description } = node.seo;
                               return (
-                                <ListItem url={pathname} key={id} iconLeft icon={iconOpt} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
+                                <ListItem
+                                  url={pathname}
+                                  key={id}
+                                  iconLeft
+                                  icon={iconOpt}
+                                  addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+                                >
                                   <div className="d-md-flex">
                                     <h3 className="h6 mb-0">
                                       <strong>{title}</strong>
@@ -98,40 +122,45 @@ function TagsDesignSystem({ children, pageContext, location, data }) {
                                       } */}
                                     </div>
                                   </div>
-                                  {(node.components?.hero?.kangaroo?.personalInfo?.items || description) &&
+                                  {(node.components?.hero?.kangaroo
+                                    ?.personalInfo?.items ||
+                                    description) && (
                                     <p className="text-secondary fw-normal d-block mb-3">
                                       <small>{description}</small>
                                     </p>
-                                  }
+                                  )}
                                 </ListItem>
-                              )
+                              );
                             })}
                           </ul>
 
                           <div className="mt-5 mb-4 border-top pt-4 px-4">
-                            <Link to="/design-system/componenti/#esplora"><strong>Esplora tutti i componenti</strong></Link>
+                            <Link to="/design-system/componenti/#esplora">
+                              <strong>Esplora tutti i componenti</strong>
+                            </Link>
                           </div>
-
                         </div>
                       </div>
 
                       <div className="mb-5 ps-4">
-                        {showTags &&
-                          <ListArchiveDSTags />
-                        }
+                        {showTags && <ListArchiveDSTags />}
                       </div>
-
                     </div>
                   </div>
                 </div>
               </section>
-
-
             </main>
           </div>
         </div>
         {children}
-        {lastModified && <LastUpdate lastModified={lastModified} {...TagPageData.lastUpdate} {...location} {...pageContext} />}
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...TagPageData.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
         <Feedback />
         <Footer {...FooterData.footer} />
         <BackToTopEl
@@ -143,52 +172,53 @@ function TagsDesignSystem({ children, pageContext, location, data }) {
         />
       </div>
     </div>
-  )
+  );
 }
 
-export default TagsDesignSystem
+export default TagsDesignSystem;
 
 export const pageQuery = graphql`
-      query($tag: String) {
-        allContentDesignSystemByTag: allContent(
-      filter: {components: {hero: {kangaroo: {tagsDesignSystem: {in: [$tag]}}}}}
+  query ($tag: String) {
+    allContentDesignSystemByTag: allContent(
+      filter: {
+        components: { hero: { kangaroo: { tagsDesignSystem: { in: [$tag] } } } }
+      }
       sort: { components: { hero: { title: ASC } } }
-      ) {
-        totalCount
+    ) {
+      totalCount
       edges {
         node {
-        id
+          id
           metadata {
-        template {
-        name
-      }
+            template {
+              name
+            }
           }
-      components {
-        hero {
-        title
+          components {
+            hero {
+              title
               tag {
-        label
-      }
-      kangaroo {
-        personalInfo {
-        items {
-        title
+                label
+              }
+              kangaroo {
+                personalInfo {
+                  items {
+                    title
                     label
                   }
                 }
               }
             }
           }
-      seo {
-        description
+          seo {
+            description
             pathname
           }
         }
       }
     }
   }
-      `
-
+`;
 
 export function Head({ pageContext: { tag } }) {
   return (
@@ -196,6 +226,6 @@ export function Head({ pageContext: { tag } }) {
       title={`${tag} - Designers Italia`}
       description={`Tutti i contenuti del design system relativi all'argomento "${tag}"`}
       pathname={`/design-system/argomenti/"${tag}"/`}
-     />
-  )
+    />
+  );
 }

--- a/src/templates/design-system-index.js
+++ b/src/templates/design-system-index.js
@@ -1,71 +1,94 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
 
-import NavSidebar from "../components/nav-sidebar/nav-sidebar"
-import Hero from "../components/hero/hero"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import FilterCards from "../components/filter-cards/filter-cards"
+import NavSidebar from "../components/nav-sidebar/nav-sidebar";
+import Hero from "../components/hero/hero";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import FilterCards from "../components/filter-cards/filter-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
-import dsNav from "../data/dsnav.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
+import dsNav from "../data/dsnav.yaml";
 
-
-function Template({children,Pagedata,pageContext,location, lastModified}) {
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   const variantMock = Pagedata.metadata.json
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    ? require(`../data/components_json/${Pagedata.metadata.json}`)
-    : null
-	return (
+    ? // eslint-disable-next-line import/no-dynamic-require, global-require
+      require(`../data/components_json/${Pagedata.metadata.json}`)
+    : null;
+  return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.name}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.name} />
         </NavWrapper>
       </Header>
       <div className="bg-light">
         <div className="container-xxl">
           <div className="row design-system">
-            <NavSidebar page={Pagedata.seo.name} {...dsNav}/>
-            <main id="main" className="col-12 col-lg-9 px-lg-0 content-column bg-white">
-              { Pagedata.components.hero && <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo}/>}
-              {Pagedata.components.sectionsEditorial?.map((section,index) => (
+            <NavSidebar page={Pagedata.seo.name} {...dsNav} />
+            <main
+              id="main"
+              className="col-12 col-lg-9 px-lg-0 content-column bg-white"
+            >
+              {Pagedata.components.hero && (
+                <Hero
+                  {...Pagedata.components.hero}
+                  pageContext={pageContext}
+                  {...Pagedata.seo}
+                />
+              )}
+              {Pagedata.components.sectionsEditorial?.map((section, index) => (
                 <SectionEditorial
                   key={`sectioneditorial-${index}`}
-                  componentViewerData={variantMock ? { variants: variantMock } : undefined}
+                  componentViewerData={
+                    variantMock ? { variants: variantMock } : undefined
+                  }
                   {...section}
                 />
               ))}
 
-              { Pagedata.components.filterCards && <FilterCards {...Pagedata.components.filterCards}/>}
+              {Pagedata.components.filterCards && (
+                <FilterCards {...Pagedata.components.filterCards} />
+              )}
 
-              {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-                  <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+              {Pagedata.components.sectionsEditorial2 &&
+                Pagedata.components.sectionsEditorial2.map((section, index) => (
+                  <SectionEditorial
+                    key={`sectionEditorial2-${index}`}
+                    {...section}
+                  />
                 ))}
-             {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
+              {lastModified && (
+                <LastUpdate
+                  lastModified={lastModified}
+                  {...Pagedata.lastUpdate}
+                  {...location}
+                  {...pageContext}
+                />
+              )}
             </main>
           </div>
         </div>
         {children}
-        <Feedback/>
+        <Feedback />
       </div>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -76,7 +99,7 @@ function Template({children,Pagedata,pageContext,location, lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -1,86 +1,106 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import HeaderPost from "../components/header-post/header-post"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import HeaderPost from "../components/header-post/header-post";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-import Highlight from "../components/highlight/highlight"
-import SearchMain from "../components/search-main/search-main"
-import ContentCollapse from "../components/content-collapse/contentCollapse"
-import SectionIntro from "../components/section-intro/section-intro"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
-import Testimonials from "../components/testimonials/testimonials"
-import BannerTextCta from "../components/banner-text-cta/banner-text-cta"
-import Numbers from "../components/numbers/numbers"
-import ImageIcons from "../components/image-icons/image-icons"
+import Highlight from "../components/highlight/highlight";
+import SearchMain from "../components/search-main/search-main";
+import ContentCollapse from "../components/content-collapse/contentCollapse";
+import SectionIntro from "../components/section-intro/section-intro";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
+import Testimonials from "../components/testimonials/testimonials";
+import BannerTextCta from "../components/banner-text-cta/banner-text-cta";
+import Numbers from "../components/numbers/numbers";
+import ImageIcons from "../components/image-icons/image-icons";
 
-function Template({Pagedata, pageContext, location, lastModified}) {
+function Template({ Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
           <HeaderNav data={HeaderData.navbar} />
         </NavWrapper>
       </Header>
-      <HeaderPost data={HeaderData.headerPost}/>
+      <HeaderPost data={HeaderData.headerPost} />
       <main id="main">
         <Highlight {...Pagedata.components.hero}>
-          {Pagedata.components.hero.moreText && <ContentCollapse label={Pagedata.components.hero.moreButton} labelClose={Pagedata.components.hero.moreButtonClose}>
-            {Pagedata.components.hero.moreText}
-          </ContentCollapse>}
+          {Pagedata.components.hero.moreText && (
+            <ContentCollapse
+              label={Pagedata.components.hero.moreButton}
+              labelClose={Pagedata.components.hero.moreButtonClose}
+            >
+              {Pagedata.components.hero.moreText}
+            </ContentCollapse>
+          )}
         </Highlight>
-        {Pagedata.components.searchMain && <SearchMain {...Pagedata.components.searchMain} />}
-        {Pagedata.components.sectionIntro && <SectionIntro {...Pagedata.components.sectionIntro} />}
-        {Pagedata.components.highLights && Pagedata.components.highLights.map((hl,index) => (
-            <Highlight key={`hl-${index}`} {...hl}/>
+        {Pagedata.components.searchMain && (
+          <SearchMain {...Pagedata.components.searchMain} />
+        )}
+        {Pagedata.components.sectionIntro && (
+          <SectionIntro {...Pagedata.components.sectionIntro} />
+        )}
+        {Pagedata.components.highLights &&
+          Pagedata.components.highLights.map((hl, index) => (
+            <Highlight key={`hl-${index}`} {...hl} />
           ))}
-        {Pagedata.components.highlightCards &&
+        {Pagedata.components.highlightCards && (
           <HighlightCards {...Pagedata.components.highlightCards} />
-        }
+        )}
 
-        {Pagedata.components.imageIcons &&
+        {Pagedata.components.imageIcons && (
           <ImageIcons {...Pagedata.components.imageIcons} />
-        }
+        )}
 
-        {Pagedata.components.sectionIntroImg &&
+        {Pagedata.components.sectionIntroImg && (
           <SectionIntro {...Pagedata.components.sectionIntroImg}>
-            {Pagedata.components.sectionIntroImg.testimonials &&
+            {Pagedata.components.sectionIntroImg.testimonials && (
               <div className="">
-                <Testimonials {...Pagedata.components.sectionIntroImg.testimonials} />
+                <Testimonials
+                  {...Pagedata.components.sectionIntroImg.testimonials}
+                />
               </div>
-            }
-          </SectionIntro>}
-        {Pagedata.components.highlightCards2 &&
+            )}
+          </SectionIntro>
+        )}
+        {Pagedata.components.highlightCards2 && (
           <HighlightCards {...Pagedata.components.highlightCards2} />
-        }
-        {Pagedata.components.bannerTextCta &&
-            <BannerTextCta {...Pagedata.components.bannerTextCta}>
-              {Pagedata.components.bannerTextCta.numbers &&
-                <Numbers {...Pagedata.components.bannerTextCta.numbers} />
-              }
-            </BannerTextCta>
-        }
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
-        <Feedback/>
+        )}
+        {Pagedata.components.bannerTextCta && (
+          <BannerTextCta {...Pagedata.components.bannerTextCta}>
+            {Pagedata.components.bannerTextCta.numbers && (
+              <Numbers {...Pagedata.components.bannerTextCta.numbers} />
+            )}
+          </BannerTextCta>
+        )}
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -91,7 +111,7 @@ function Template({Pagedata, pageContext, location, lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/level-1-community.js
+++ b/src/templates/level-1-community.js
@@ -1,66 +1,84 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
 // import HeaderPost from "../components/header-post/header-post"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
 
-import Hero from "../components/hero/hero"
-import SectionIntro from "../components/section-intro/section-intro"
-import TitleText from "../components/title-text/title-text"
-import Highlight from "../components/highlight/highlight"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import SectionIntro from "../components/section-intro/section-intro";
+import TitleText from "../components/title-text/title-text";
+import Highlight from "../components/highlight/highlight";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-function Template({children,Pagedata,pageContext,location, lastModified}) {
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
+  let activePage = null;
 
-    let activePage = null
-
-    if (Pagedata.metadata?.activeLabel) {
-      activePage = Pagedata.metadata.activeLabel
-    }
+  if (Pagedata.metadata?.activeLabel) {
+    activePage = Pagedata.metadata.activeLabel;
+  }
 
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={activePage}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={activePage} />
         </NavWrapper>
       </Header>
       <main id="main">
-        { Pagedata.components?.hero && <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />}
-        { Pagedata.components?.sectionIntro && <SectionIntro {...Pagedata.components.sectionIntro}/>}
+        {Pagedata.components?.hero && (
+          <Hero
+            {...Pagedata.components.hero}
+            pageContext={pageContext}
+            {...Pagedata.seo}
+          />
+        )}
+        {Pagedata.components?.sectionIntro && (
+          <SectionIntro {...Pagedata.components.sectionIntro} />
+        )}
 
-        { Pagedata.components?.titleText && <TitleText {...Pagedata.components.titleText}/>}
+        {Pagedata.components?.titleText && (
+          <TitleText {...Pagedata.components.titleText} />
+        )}
 
-        { Pagedata.components?.highlightCardsLoop && Pagedata.components.highlightCardsLoop.map((hlc,index) => (
-            <HighlightCards key={`hcl-${index}`} {...hlc}/>
+        {Pagedata.components?.highlightCardsLoop &&
+          Pagedata.components.highlightCardsLoop.map((hlc, index) => (
+            <HighlightCards key={`hcl-${index}`} {...hlc} />
           ))}
 
-        { Pagedata.components?.highlightsLoop && Pagedata.components.highlightsLoop.map((hl,index) => (
-            <Highlight key={`hl-${index}`} {...hl}/>
+        {Pagedata.components?.highlightsLoop &&
+          Pagedata.components.highlightsLoop.map((hl, index) => (
+            <Highlight key={`hl-${index}`} {...hl} />
           ))}
 
         {children}
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
-        <Feedback/>
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -71,7 +89,7 @@ function Template({children,Pagedata,pageContext,location, lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/level-1.js
+++ b/src/templates/level-1.js
@@ -1,73 +1,96 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderPre from "../components/header-pre/header-pre"
-import HeaderSlim from "../components/header-slim/header-slim"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderPre from "../components/header-pre/header-pre";
+import HeaderSlim from "../components/header-slim/header-slim";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
 
-import Hero from "../components/hero/hero"
-import SectionIntro from "../components/section-intro/section-intro"
-import TitleText from "../components/title-text/title-text"
-import Highlight from "../components/highlight/highlight"
-import ImageIcons from "../components/image-icons/image-icons"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
-import Topics from "../components/topics/topics"
+import Hero from "../components/hero/hero";
+import SectionIntro from "../components/section-intro/section-intro";
+import TitleText from "../components/title-text/title-text";
+import Highlight from "../components/highlight/highlight";
+import ImageIcons from "../components/image-icons/image-icons";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
+import Topics from "../components/topics/topics";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
+  let activePage = null;
 
-  let activePage = null
-
-    if (Pagedata.metadata.activeLabel) {
-        activePage = Pagedata.metadata.activeLabel
-    }
+  if (Pagedata.metadata.activeLabel) {
+    activePage = Pagedata.metadata.activeLabel;
+  }
 
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={activePage}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={activePage} />
         </NavWrapper>
       </Header>
       <main id="main">
+        {Pagedata.components.hero && (
+          <Hero
+            {...Pagedata.components.hero}
+            pageContext={pageContext}
+            {...Pagedata.seo}
+          />
+        )}
+        {Pagedata.components.sectionIntro && (
+          <SectionIntro {...Pagedata.components.sectionIntro} />
+        )}
+        {Pagedata.components.titleText && (
+          <TitleText {...Pagedata.components.titleText} />
+        )}
 
-        { Pagedata.components.hero && <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />}
-        { Pagedata.components.sectionIntro && <SectionIntro {...Pagedata.components.sectionIntro}/>}
-        { Pagedata.components.titleText && <TitleText {...Pagedata.components.titleText}/>}
-
-        { Pagedata.components.highlightsLoop1 && Pagedata.components.highlightsLoop1.map((hl,index) => (
-            <Highlight key={`hl-${index}`} {...hl}/>
+        {Pagedata.components.highlightsLoop1 &&
+          Pagedata.components.highlightsLoop1.map((hl, index) => (
+            <Highlight key={`hl-${index}`} {...hl} />
           ))}
 
-        { Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
 
-        { Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} /> }
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
 
-        { Pagedata.components.highlightsLoop2 && Pagedata.components.highlightsLoop2.map((hl,index) => (
-            <Highlight key={`hl-${index}`} {...hl}/>
+        {Pagedata.components.highlightsLoop2 &&
+          Pagedata.components.highlightsLoop2.map((hl, index) => (
+            <Highlight key={`hl-${index}`} {...hl} />
           ))}
 
-        { Pagedata.components.topics && <Topics {...Pagedata.components.topics}/> }
+        {Pagedata.components.topics && (
+          <Topics {...Pagedata.components.topics} />
+        )}
 
         {children}
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
-        <Feedback/>
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -78,7 +101,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/level-2.js
+++ b/src/templates/level-2.js
@@ -1,56 +1,72 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
 
-import Hero from "../components/hero/hero"
-import ImageIcons from "../components/image-icons/image-icons"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import ImageIcons from "../components/image-icons/image-icons";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
-
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page} />
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />
-        {Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
-        {Pagedata.components.sectionsEditorial && Pagedata.components.sectionsEditorial.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial-${index}`} {...section}/>
+        <Hero
+          {...Pagedata.components.hero}
+          pageContext={pageContext}
+          {...Pagedata.seo}
+        />
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
+        {Pagedata.components.sectionsEditorial &&
+          Pagedata.components.sectionsEditorial.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial-${index}`} {...section} />
           ))}
-        {Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} />}
-        {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
+        {Pagedata.components.sectionsEditorial2 &&
+          Pagedata.components.sectionsEditorial2.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial2-${index}`} {...section} />
           ))}
         {children}
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
         {Pagedata.navPreFooter && <NavPreFooter {...Pagedata.navPreFooter} />}
-        <Feedback/>
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -61,7 +77,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/level-3.js
+++ b/src/templates/level-3.js
@@ -1,55 +1,72 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
 
-import Hero from "../components/hero/hero"
-import ImageIcons from "../components/image-icons/image-icons"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import ImageIcons from "../components/image-icons/image-icons";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
-import Kangaroo from "../components/kangaroo/kangaroo"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
+import Kangaroo from "../components/kangaroo/kangaroo";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page} />
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />
-        {Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
-        {Pagedata.components.sectionsEditorial && Pagedata.components.sectionsEditorial.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial-${index}`} {...section}/>
+        <Hero
+          {...Pagedata.components.hero}
+          pageContext={pageContext}
+          {...Pagedata.seo}
+        />
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
+        {Pagedata.components.sectionsEditorial &&
+          Pagedata.components.sectionsEditorial.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial-${index}`} {...section} />
           ))}
-        {Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} />}
-        {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
+        {Pagedata.components.sectionsEditorial2 &&
+          Pagedata.components.sectionsEditorial2.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial2-${index}`} {...section} />
           ))}
         {children}
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
-        {Pagedata.kangaroo &&
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        {Pagedata.kangaroo && (
           <div className="container-xxl">
             <div className="row">
               <div className="col-12 g-0">
@@ -57,9 +74,9 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
               </div>
             </div>
           </div>
-        }
+        )}
         {Pagedata.navPreFooter && <NavPreFooter {...Pagedata.navPreFooter} />}
-        <Feedback/>
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -70,7 +87,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/level-4.js
+++ b/src/templates/level-4.js
@@ -1,57 +1,76 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
-import ResourceList from "../components/resource-list/resource-list"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
+import ResourceList from "../components/resource-list/resource-list";
 
-import Hero from "../components/hero/hero"
-import ImageIcons from "../components/image-icons/image-icons"
-import SectionEditorial from "../components/section-editorial/section-editorial"
-import HighlightCards from "../components/highlight-cards/highlight-cards"
+import Hero from "../components/hero/hero";
+import ImageIcons from "../components/image-icons/image-icons";
+import SectionEditorial from "../components/section-editorial/section-editorial";
+import HighlightCards from "../components/highlight-cards/highlight-cards";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
-import Kangaroo from "../components/kangaroo/kangaroo"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
+import Kangaroo from "../components/kangaroo/kangaroo";
 
-function Template({children,Pagedata,pageContext,location,lastModified}) {
+function Template({ children, Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
-          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
+          <HeaderNav data={HeaderData.navbar} page={Pagedata.seo.page} />
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />
-        {Pagedata.components.imageIcons && <ImageIcons {...Pagedata.components.imageIcons}/>}
-        {Pagedata.components.sectionsEditorial && Pagedata.components.sectionsEditorial.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial-${index}`} {...section}/>
+        <Hero
+          {...Pagedata.components.hero}
+          pageContext={pageContext}
+          {...Pagedata.seo}
+        />
+        {Pagedata.components.imageIcons && (
+          <ImageIcons {...Pagedata.components.imageIcons} />
+        )}
+        {Pagedata.components.sectionsEditorial &&
+          Pagedata.components.sectionsEditorial.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial-${index}`} {...section} />
           ))}
-        {Pagedata.components.resourceList && <ResourceList {...Pagedata.components.resourceList}/>}
-        {Pagedata.components.highlightCards && <HighlightCards {...Pagedata.components.highlightCards} />}
-        {Pagedata.components.sectionsEditorial2 && Pagedata.components.sectionsEditorial2.map((section,index) => (
-            <SectionEditorial key={`sectionEditorial2-${index}`} {...section}/>
+        {Pagedata.components.resourceList && (
+          <ResourceList {...Pagedata.components.resourceList} />
+        )}
+        {Pagedata.components.highlightCards && (
+          <HighlightCards {...Pagedata.components.highlightCards} />
+        )}
+        {Pagedata.components.sectionsEditorial2 &&
+          Pagedata.components.sectionsEditorial2.map((section, index) => (
+            <SectionEditorial key={`sectionEditorial2-${index}`} {...section} />
           ))}
         {children}
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
-        {Pagedata.kangaroo &&
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        {Pagedata.kangaroo && (
           <div className="container-xxl">
             <div className="row">
               <div className="col-12">
@@ -59,9 +78,9 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
               </div>
             </div>
           </div>
-        }
+        )}
         {Pagedata.navPreFooter && <NavPreFooter {...Pagedata.navPreFooter} />}
-        <Feedback/>
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -72,7 +91,7 @@ function Template({children,Pagedata,pageContext,location,lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/search-results.js
+++ b/src/templates/search-results.js
@@ -1,44 +1,59 @@
-import * as React from "react"
-import "../scss/styles.scss"
-import "../js/globals"
+import * as React from "react";
+import "../scss/styles.scss";
+import "../js/globals";
 
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
 
-import Hero from "../components/hero/hero"
+import Hero from "../components/hero/hero";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-import SearchMain from "../components/search-main/search-main"
+import SearchMain from "../components/search-main/search-main";
 
-function Template({Pagedata, pageContext, location, lastModified}) {
+function Template({ Pagedata, pageContext, location, lastModified }) {
   return (
     <div id="app">
-      <HeaderPre data={HeaderData.headerPre} location={location}/>
-      <Skiplinks data={skipLinksData.skiplinks}/>
+      <HeaderPre data={HeaderData.headerPre} location={location} />
+      <Skiplinks data={skipLinksData.skiplinks} />
       <Header data={HeaderData}>
-        <HeaderSlim data={HeaderData.headerSlim}/>
+        <HeaderSlim data={HeaderData.headerSlim} />
         <NavWrapper>
-          <HeaderCenter data={HeaderData.headerCenter}/>
+          <HeaderCenter data={HeaderData.headerCenter} />
           <HeaderNav data={HeaderData.navbar} />
         </NavWrapper>
       </Header>
       <main id="main">
-        {Pagedata.components.hero && <Hero {...Pagedata.components.hero} pageContext={pageContext} {...Pagedata.seo} />}
-        {Pagedata.components.searchMain && <SearchMain {...Pagedata.components.searchMain} location={location} />}
-        {lastModified && <LastUpdate lastModified={lastModified} {...Pagedata.lastUpdate} {...location} {...pageContext}/>}
-        <Feedback/>
+        {Pagedata.components.hero && (
+          <Hero
+            {...Pagedata.components.hero}
+            pageContext={pageContext}
+            {...Pagedata.seo}
+          />
+        )}
+        {Pagedata.components.searchMain && (
+          <SearchMain {...Pagedata.components.searchMain} location={location} />
+        )}
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...Pagedata.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        <Feedback />
       </main>
       <Footer {...FooterData.footer} />
       <BackToTopEl
@@ -49,7 +64,7 @@ function Template({Pagedata, pageContext, location, lastModified}) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-	)
+  );
 }
 
-export default Template
+export default Template;

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -1,53 +1,56 @@
-import * as React from "react"
+import * as React from "react";
 
-import "../scss/styles.scss"
-import "../js/globals"
+import "../scss/styles.scss";
+import "../js/globals";
 
-import { graphql } from "gatsby"
-import Skiplinks from "../components/skiplinks/skiplinks"
-import Header from "../components/header/header"
-import Footer from "../components/footer/footer"
-import BackToTopEl from "../components/back-to-top/back-to-top"
-import HeaderSlim from "../components/header-slim/header-slim"
-import HeaderPre from "../components/header-pre/header-pre"
-import NavWrapper from "../components/nav-wrapper/nav-wrapper"
-import HeaderCenter from "../components/header-center/header-center"
-import HeaderNav from "../components/header-nav/header-nav"
-import LastUpdate from "../components/last-update/last-update"
-import Feedback from "../components/feedback/feedback"
-import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer"
+import { graphql } from "gatsby";
+import Skiplinks from "../components/skiplinks/skiplinks";
+import Header from "../components/header/header";
+import Footer from "../components/footer/footer";
+import BackToTopEl from "../components/back-to-top/back-to-top";
+import HeaderSlim from "../components/header-slim/header-slim";
+import HeaderPre from "../components/header-pre/header-pre";
+import NavWrapper from "../components/nav-wrapper/nav-wrapper";
+import HeaderCenter from "../components/header-center/header-center";
+import HeaderNav from "../components/header-nav/header-nav";
+import LastUpdate from "../components/last-update/last-update";
+import Feedback from "../components/feedback/feedback";
+import NavPreFooter from "../components/nav-pre-footer/nav-pre-footer";
 
-import Hero from "../components/hero/hero"
+import Hero from "../components/hero/hero";
 
-import HeaderData from "../data/header.yaml"
-import FooterData from "../data/footer.yaml"
-import TagPageData from "../data/tag.yaml"
-import skipLinksData from "../data/skiplinks.yaml"
+import HeaderData from "../data/header.yaml";
+import FooterData from "../data/footer.yaml";
+import TagPageData from "../data/tag.yaml";
+import skipLinksData from "../data/skiplinks.yaml";
 
-import Link from "../components/link/link"
-import ListItem from "../components/list-item/list-item"
-import Tag from "../components/tag/tag"
+import Link from "../components/link/link";
+import ListItem from "../components/list-item/list-item";
+import Tag from "../components/tag/tag";
 
-import { Seo } from "../components/seo/seo"
+import { Seo } from "../components/seo/seo";
 
 function Tags({ children, pageContext, location, data }) {
-  const lastModified = data.content?.parent?.fields?.gitLogLatestDate || new Date(0).toISOString()
+  const lastModified =
+    data.content?.parent?.fields?.gitLogLatestDate || new Date(0).toISOString();
 
-  const { tag } = pageContext
-  const { edges, totalCount } = data.allContentByTag
-  const tagHeader = `Esplora ${totalCount} pagin${totalCount === 1 ? "a" : "e"} su questo argomento`
+  const { tag } = pageContext;
+  const { edges, totalCount } = data.allContentByTag;
+  const tagHeader = `Esplora ${totalCount} pagin${
+    totalCount === 1 ? "a" : "e"
+  } su questo argomento`;
 
   const iconOpt = {
-    icon: 'sprites.svg#it-file',
-    size: 'sm',
+    icon: "sprites.svg#it-file",
+    size: "sm",
     color: "primary",
-    addonClasses: 'mt-1 flex-shrink-0 me-1 me-md-3'
-  }
+    addonClasses: "mt-1 flex-shrink-0 me-1 me-md-3",
+  };
 
-  const container = "container-xxl"
-  const row = "row"
+  const container = "container-xxl";
+  const row = "row";
 
-  const styles = 'section-editorial'
+  const styles = "section-editorial";
 
   return (
     <div id="app">
@@ -61,54 +64,89 @@ function Tags({ children, pageContext, location, data }) {
         </NavWrapper>
       </Header>
       <main id="main">
-        <Hero {...TagPageData.components.hero} title={tag} subtitle={`Tutti i contenuti relativi all'argomento "${tag}"`} crumbLabel={tag} pageContext={pageContext} {...TagPageData.seo} />
+        <Hero
+          {...TagPageData.components.hero}
+          title={tag}
+          subtitle={`Tutti i contenuti relativi all'argomento "${tag}"`}
+          crumbLabel={tag}
+          pageContext={pageContext}
+          {...TagPageData.seo}
+        />
         {/* <Hero {...TagPageData.components.hero} title={`Argomento: "${tag}"`} crumbLabel={tag} pageContext={pageContext} {...TagPageData.seo}></Hero> */}
         <section className={styles} aria-describedby="archive-list-title">
           <div className={container}>
             <div className={row}>
               <div className="col-12 g-0">
                 <div className="px-3 px-lg-0 px-lg-5">
-                  <h2 className="border-bottom pb-4" id="archive-list-title">{tagHeader}</h2>
+                  <h2 className="border-bottom pb-4" id="archive-list-title">
+                    {tagHeader}
+                  </h2>
                   <div className="it-list-wrapper">
                     <ul className="it-list mt-4 mt-md-3">
                       {edges.map(({ node }) => {
-                        const { id } = node
-                        const { pathname } = node.seo
-                        const title = node.components?.hero?.title
-                        const { description } = node.seo
+                        const { id } = node;
+                        const { pathname } = node.seo;
+                        const title = node.components?.hero?.title;
+                        const { description } = node.seo;
                         return (
-                          <ListItem url={pathname} key={id} iconLeft icon={iconOpt} addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4">
+                          <ListItem
+                            url={pathname}
+                            key={id}
+                            iconLeft
+                            icon={iconOpt}
+                            addonClasses="align-items-start border-bottom-0 pt-3 px-0 px-sm-2 px-md-4"
+                          >
                             <div className="d-md-flex">
                               <h3 className="h6 mb-0">
                                 <strong>{title}</strong>
                               </h3>
                               <div>
-                                {node.components?.hero?.tag?.label &&
+                                {node.components?.hero?.tag?.label && (
                                   <div className="mb-2 mt-1 mb-md-0 mt-md-0">
-                                    <Tag label={node.components?.hero?.tag?.label} addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal" />
+                                    <Tag
+                                      label={node.components?.hero?.tag?.label}
+                                      addonClasses="ms-md-4 text-uppercase px-2 py-0 fw-normal"
+                                    />
                                   </div>
-                                }
+                                )}
                                 {node.metadata?.template?.name &&
-                                  (node.metadata?.template?.name === 'level1' || node.metadata?.template?.name === 'community') ?
+                                (node.metadata?.template?.name === "level1" ||
+                                  node.metadata?.template?.name ===
+                                    "community") ? (
                                   <div className="mb-2 mt-1 mb-md-0 mt-md-0 d-table d-sm-table d-md-inline-block ">
-                                    <Tag label="Panoramica" addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal" />
+                                    <Tag
+                                      label="Panoramica"
+                                      addonClasses="ms-md-4 text-uppercase bg-primary px-2 py-0 fw-normal"
+                                    />
                                   </div>
-                                  : null}
+                                ) : null}
                               </div>
                             </div>
-                            {(node.components?.hero?.kangaroo?.personalInfo?.items || description) &&
+                            {(node.components?.hero?.kangaroo?.personalInfo
+                              ?.items ||
+                              description) && (
                               <p className="text-secondary fw-normal d-block mb-3">
-                                {node.components?.hero?.kangaroo?.personalInfo?.items &&
-                                  <small>{node.components?.hero?.kangaroo?.personalInfo?.items[1].label}</small>} {/* // XXX WE NEED AN UNIVERSAL NEWS DATE FIELD */}
+                                {node.components?.hero?.kangaroo?.personalInfo
+                                  ?.items && (
+                                  <small>
+                                    {
+                                      node.components?.hero?.kangaroo
+                                        ?.personalInfo?.items[1].label
+                                    }
+                                  </small>
+                                )}{" "}
+                                {/* // XXX WE NEED AN UNIVERSAL NEWS DATE FIELD */}
                                 <small> — {description}</small>
                               </p>
-                            }
+                            )}
                           </ListItem>
-                        )
+                        );
                       })}
                     </ul>
                     <div className="my-5 border-top pt-4 px-4">
-                      <Link to="/argomenti/"><strong>Scopri tutti gli argomenti</strong></Link>
+                      <Link to="/argomenti/">
+                        <strong>Scopri tutti gli argomenti</strong>
+                      </Link>
                     </div>
                   </div>
                 </div>
@@ -117,8 +155,17 @@ function Tags({ children, pageContext, location, data }) {
           </div>
         </section>
         {children}
-        {lastModified && <LastUpdate lastModified={lastModified} {...TagPageData.lastUpdate} {...location} {...pageContext} />}
-        {TagPageData.navPreFooter && <NavPreFooter {...TagPageData.navPreFooter} />}
+        {lastModified && (
+          <LastUpdate
+            lastModified={lastModified}
+            {...TagPageData.lastUpdate}
+            {...location}
+            {...pageContext}
+          />
+        )}
+        {TagPageData.navPreFooter && (
+          <NavPreFooter {...TagPageData.navPreFooter} />
+        )}
         <Feedback />
       </main>
       <Footer {...FooterData.footer} />
@@ -130,15 +177,15 @@ function Tags({ children, pageContext, location, data }) {
         ariaLabel={FooterData.footer.backToTop.ariaLabel}
       />
     </div>
-  )
+  );
 }
 
-export default Tags
+export default Tags;
 
 export const pageQuery = graphql`
-  query($tag: String) {
+  query ($tag: String) {
     allContentByTag: allContent(
-      filter: {components: {hero: {kangaroo: {tags: {in: [$tag]}}}}}
+      filter: { components: { hero: { kangaroo: { tags: { in: [$tag] } } } } }
       sort: { components: { hero: { title: ASC } } }
     ) {
       totalCount
@@ -174,15 +221,14 @@ export const pageQuery = graphql`
       }
     }
   }
-`
-
+`;
 
 export function Head({ pageContext: { tag } }) {
   return (
-  <Seo
-    title = {`${tag} - Designers Italia`}
-    description = {`Tutti i contenuti relativi all'argomento "${tag}"`}
-    pathname = {`/argomenti/"${tag}"/`}
-   />
-  )
+    <Seo
+      title={`${tag} - Designers Italia`}
+      description={`Tutti i contenuti relativi all'argomento "${tag}"`}
+      pathname={`/argomenti/"${tag}"/`}
+    />
+  );
 }


### PR DESCRIPTION
`prettier` needs to be configured in eslint with `"plugin:prettier/recommended"`,
as documented at
https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
    
The previous config didn't really work and acted as if prettier was
disabled.
    
Also use `classnames` to avoid string concatenation. The linter
doesn't catch all the occurrences, so there may be places where
concatenation for classes is still there.

Fix https://github.com/italia/designers.italia.it/issues/742
Fix https://github.com/italia/designers.italia.it/issues/630
Fix https://github.com/italia/designers.italia.it/issues/848