### PR TITLE
feat: only print tags and redir generation in debug mode

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -126,7 +126,9 @@ exports.createPages = async ({ graphql, actions }) => {
     }
   `);
   tags.data.tagsGroup.group.forEach((tag) => {
-    console.log(`Creating tag page: ${tag.fieldValue}`);
+    if (process.env.DEBUG === "true") {
+      console.log(`Creating tag page: ${tag.fieldValue}`);
+    }
     createPage({
       path: `/argomenti/${_.kebabCase(tag.fieldValue)}/`,
       component: tagTemplate,
@@ -153,7 +155,9 @@ exports.createPages = async ({ graphql, actions }) => {
     }
   `);
   tagsDesignSystem.data.tagsDesignSystemGroup.group.forEach((tag) => {
-    console.log(`Creating tag page: ${tag.fieldValue}`);
+    if (process.env.DEBUG === "true") {
+      console.log(`Creating tag page: ${tag.fieldValue}`);
+    }
     createPage({
       path: `/design-system/componenti/utili-per/${_.kebabCase(
         tag.fieldValue,
@@ -187,7 +191,10 @@ exports.createPages = async ({ graphql, actions }) => {
     const { node } = edge;
     node.metadata.redirect_from.forEach((fromPath) => {
       const toPath = edge.node.seo.pathname;
-      console.log(`Creating redirect: ${fromPath} -> ${toPath}...`);
+      if (process.env.DEBUG === "true") {
+        console.log(`Creating redirect: ${fromPath} -> ${toPath}...`);
+      }
+
       createRedirect({ fromPath, toPath });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "gh-pages": "^6.0.0",
         "mustache": "^4.2.0",
         "prettier": "3.0.3",
-        "recursive-copy-cli": "^1.0.20",
         "slugify": "^1.6.5"
       }
     },
@@ -5240,14 +5239,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-differ": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -6513,19 +6504,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/clone": {
@@ -7949,17 +7927,6 @@
     "node_modules/eol": {
       "version": "0.9.1",
       "license": "MIT"
-    },
-    "node_modules/errno": {
-      "version": "0.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prr": "~1.0.1"
-      },
-      "bin": {
-        "errno": "cli.js"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -11841,14 +11808,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/highland": {
-      "version": "2.13.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "util-deprecate": "^1.0.2"
-      }
-    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "license": "BSD-3-Clause",
@@ -13164,14 +13123,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/junk": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/just-validate": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/just-validate/-/just-validate-3.10.0.tgz",
@@ -13586,39 +13537,6 @@
       "dependencies": {
         "get-size": "^2.0.2",
         "outlayer": "^2.1.0"
-      }
-    },
-    "node_modules/maximatch": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/maximatch/node_modules/array-union": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/maximatch/node_modules/arrify": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -14703,11 +14621,6 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "license": "MIT"
-    },
-    "node_modules/nested-error-stacks": {
-      "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/next-tick": {
@@ -16517,11 +16430,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/prr": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "license": "ISC"
@@ -16986,78 +16894,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/recursive-copy": {
-      "version": "2.0.14",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "errno": "^0.1.2",
-        "graceful-fs": "^4.1.4",
-        "junk": "^1.0.1",
-        "maximatch": "^0.1.0",
-        "mkdirp": "^0.5.1",
-        "pify": "^2.3.0",
-        "promise": "^7.0.1",
-        "rimraf": "^2.7.1",
-        "slash": "^1.0.0"
-      }
-    },
-    "node_modules/recursive-copy-cli": {
-      "version": "1.0.20",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "highland": "^2.13.5",
-        "lodash": "^4.17.19",
-        "recursive-copy": "^2.0.10",
-        "requireg": "^0.2.2",
-        "yargs": "^17.0.1"
-      },
-      "bin": {
-        "recursive-copy": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
-    "node_modules/recursive-copy/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/recursive-copy/node_modules/rimraf": {
-      "version": "2.7.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/recursive-copy/node_modules/slash": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "license": "MIT",
@@ -17326,26 +17162,6 @@
     "node_modules/require-package-name": {
       "version": "2.0.1",
       "license": "MIT"
-    },
-    "node_modules/requireg": {
-      "version": "0.2.2",
-      "dev": true,
-      "dependencies": {
-        "nested-error-stacks": "~2.0.1",
-        "rc": "~1.2.7",
-        "resolve": "~1.7.1"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/requireg/node_modules/resolve": {
-      "version": "1.7.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-parse": "^1.0.5"
-      }
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -20023,14 +19839,6 @@
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
       "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA=="
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "2.1.2",
       "license": "ISC"
@@ -20063,23 +19871,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
@@ -20098,14 +19889,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "site"
   ],
   "scripts": {
-    "prepare-lib": "recursive-copy -w ./node_modules/bootstrap-italia/dist/svg/ ./static/svg/ && recursive-copy -w ./node_modules/bootstrap-italia/dist/svg/ ./static/dist/svg/ && recursive-copy -w ./node_modules/bootstrap-italia/dist/fonts/ ./static/fonts/ && recursive-copy -w ./node_modules/bootstrap-italia/dist/fonts/ ./static/dist/fonts/",
+    "prepare-lib": "cp -r node_modules/bootstrap-italia/dist/svg/ static/ && cp -r node_modules/bootstrap-italia/dist/fonts static/",
     "prepare-content": "node ./scripts/prepare.js",
     "start": "npm run prepare-lib && gatsby develop",
     "develop": "npm run start",
@@ -88,7 +88,6 @@
     "gh-pages": "^6.0.0",
     "mustache": "^4.2.0",
     "prettier": "3.0.3",
-    "recursive-copy-cli": "^1.0.20",
     "slugify": "^1.6.5"
   }
 }

--- a/static/examples/bsi/come-iniziare/componente-base/base.html
+++ b/static/examples/bsi/come-iniziare/componente-base/base.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/accordion/accordion-annidati.html
+++ b/static/examples/bsi/componenti/accordion/accordion-annidati.html
@@ -194,7 +194,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/accordion/accordion.html
+++ b/static/examples/bsi/componenti/accordion/accordion.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/accordion/base.html
+++ b/static/examples/bsi/componenti/accordion/base.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/accordion/con-icona-a-sinistra.html
+++ b/static/examples/bsi/componenti/accordion/con-icona-a-sinistra.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/accordion/con-sfondo-header-all'hover.html
+++ b/static/examples/bsi/componenti/accordion/con-sfondo-header-all'hover.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/accordion/con-sfondo-header-attivi.html
+++ b/static/examples/bsi/componenti/accordion/con-sfondo-header-attivi.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/affix/orizzontale-in-alto.html
+++ b/static/examples/bsi/componenti/affix/orizzontale-in-alto.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/affix/orizzontale-in-basso.html
+++ b/static/examples/bsi/componenti/affix/orizzontale-in-basso.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/affix/verticale-in-alto.html
+++ b/static/examples/bsi/componenti/affix/verticale-in-alto.html
@@ -141,7 +141,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/affix/verticale-in-basso.html
+++ b/static/examples/bsi/componenti/affix/verticale-in-basso.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/alert/contenuto-aggiuntivo.html
+++ b/static/examples/bsi/componenti/alert/contenuto-aggiuntivo.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/alert/link-evidenziato.html
+++ b/static/examples/bsi/componenti/alert/link-evidenziato.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/alert/pulsante-di-chiusura.html
+++ b/static/examples/bsi/componenti/alert/pulsante-di-chiusura.html
@@ -127,7 +127,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/alert/varianti-per-tipologia.html
+++ b/static/examples/bsi/componenti/alert/varianti-per-tipologia.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/con-comportamento-presenza-utente.html
+++ b/static/examples/bsi/componenti/avatar/con-comportamento-presenza-utente.html
@@ -185,7 +185,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/con-comportamento-status-utente.html
+++ b/static/examples/bsi/componenti/avatar/con-comportamento-status-utente.html
@@ -185,7 +185,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/con-testo-aggiuntivo.html
+++ b/static/examples/bsi/componenti/avatar/con-testo-aggiuntivo.html
@@ -149,7 +149,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/gruppo-lista-media.html
+++ b/static/examples/bsi/componenti/avatar/gruppo-lista-media.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/gruppo-lista-piccola.html
+++ b/static/examples/bsi/componenti/avatar/gruppo-lista-piccola.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/gruppo-sovrapposti-medi.html
+++ b/static/examples/bsi/componenti/avatar/gruppo-sovrapposti-medi.html
@@ -197,7 +197,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/gruppo-sovrapposti-piccoli.html
+++ b/static/examples/bsi/componenti/avatar/gruppo-sovrapposti-piccoli.html
@@ -213,7 +213,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/icona.html
+++ b/static/examples/bsi/componenti/avatar/icona.html
@@ -145,7 +145,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/immagine.html
+++ b/static/examples/bsi/componenti/avatar/immagine.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/link-con-tooltip.html
+++ b/static/examples/bsi/componenti/avatar/link-con-tooltip.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/link.html
+++ b/static/examples/bsi/componenti/avatar/link.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/avatar/testo.html
+++ b/static/examples/bsi/componenti/avatar/testo.html
@@ -145,7 +145,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/badge/arrotondati.html
+++ b/static/examples/bsi/componenti/badge/arrotondati.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/badge/base.html
+++ b/static/examples/bsi/componenti/badge/base.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/badge/in-pulsante-per-screen-reader.html
+++ b/static/examples/bsi/componenti/badge/in-pulsante-per-screen-reader.html
@@ -122,7 +122,7 @@ Profilo <span class="badge bg-white text-primary">9</span>
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/badge/in-pulsante.html
+++ b/static/examples/bsi/componenti/badge/in-pulsante.html
@@ -121,7 +121,7 @@ Notifiche <span class="badge bg-white text-secondary">4</span>
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/badge/link.html
+++ b/static/examples/bsi/componenti/badge/link.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/badge/varianti-di-colore.html
+++ b/static/examples/bsi/componenti/badge/varianti-di-colore.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/a-tutta-larghezza-solo-su-mobile.html
+++ b/static/examples/bsi/componenti/buttons/a-tutta-larghezza-solo-su-mobile.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/a-tutta-larghezza.html
+++ b/static/examples/bsi/componenti/buttons/a-tutta-larghezza.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/base.html
+++ b/static/examples/bsi/componenti/buttons/base.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/con-classe-.btn.html
+++ b/static/examples/bsi/componenti/buttons/con-classe-.btn.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/con-icona-cerchiata.html
+++ b/static/examples/bsi/componenti/buttons/con-icona-cerchiata.html
@@ -153,7 +153,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/con-icona.html
+++ b/static/examples/bsi/componenti/buttons/con-icona.html
@@ -153,7 +153,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/dimensione-grande.html
+++ b/static/examples/bsi/componenti/buttons/dimensione-grande.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/dimensione-minima.html
+++ b/static/examples/bsi/componenti/buttons/dimensione-minima.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/dimensione-normale.html
+++ b/static/examples/bsi/componenti/buttons/dimensione-normale.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/disabilitato.html
+++ b/static/examples/bsi/componenti/buttons/disabilitato.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/su-fondo-scuro.html
+++ b/static/examples/bsi/componenti/buttons/su-fondo-scuro.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/buttons/varianti-di-colore.html
+++ b/static/examples/bsi/componenti/buttons/varianti-di-colore.html
@@ -151,7 +151,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/approfondimento.html
+++ b/static/examples/bsi/componenti/callout/approfondimento.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/attenzione-in-evidenza.html
+++ b/static/examples/bsi/componenti/callout/attenzione-in-evidenza.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/attenzione.html
+++ b/static/examples/bsi/componenti/callout/attenzione.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/importante-in-evidenza.html
+++ b/static/examples/bsi/componenti/callout/importante-in-evidenza.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/importante.html
+++ b/static/examples/bsi/componenti/callout/importante.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/nota-in-evidenza.html
+++ b/static/examples/bsi/componenti/callout/nota-in-evidenza.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/nota.html
+++ b/static/examples/bsi/componenti/callout/nota.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/pericolo-o-errore-in-evidenza.html
+++ b/static/examples/bsi/componenti/callout/pericolo-o-errore-in-evidenza.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/pericolo-o-errore.html
+++ b/static/examples/bsi/componenti/callout/pericolo-o-errore.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/periocolo-o-errore-in-evidenza.html
+++ b/static/examples/bsi/componenti/callout/periocolo-o-errore-in-evidenza.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.6.2/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/successo-in-evidenza.html
+++ b/static/examples/bsi/componenti/callout/successo-in-evidenza.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/successo.html
+++ b/static/examples/bsi/componenti/callout/successo.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/testo-in-evidenza.html
+++ b/static/examples/bsi/componenti/callout/testo-in-evidenza.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/callout/testo.html
+++ b/static/examples/bsi/componenti/callout/testo.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/base-articolo.html
+++ b/static/examples/bsi/componenti/card/base-articolo.html
@@ -144,7 +144,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/base-su-piu-colonne.html
+++ b/static/examples/bsi/componenti/card/base-su-piu-colonne.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/base.html
+++ b/static/examples/bsi/componenti/card/base.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/con-icona-sottotitolo-e-link.html
+++ b/static/examples/bsi/componenti/card/con-icona-sottotitolo-e-link.html
@@ -142,7 +142,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/con-icona.html
+++ b/static/examples/bsi/componenti/card/con-icona.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/con-immagine.html
+++ b/static/examples/bsi/componenti/card/con-immagine.html
@@ -229,7 +229,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/con-ombra-grande-con-categoria-ed-in-evidenza.html
+++ b/static/examples/bsi/componenti/card/con-ombra-grande-con-categoria-ed-in-evidenza.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/con-ombra-grande-con-tag-data-e-call-to-action.html
+++ b/static/examples/bsi/componenti/card/con-ombra-grande-con-tag-data-e-call-to-action.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/con-ombra-grande.html
+++ b/static/examples/bsi/componenti/card/con-ombra-grande.html
@@ -144,7 +144,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/con-ombra.html
+++ b/static/examples/bsi/componenti/card/con-ombra.html
@@ -139,7 +139,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/speciale.html
+++ b/static/examples/bsi/componenti/card/speciale.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/card/teaser.html
+++ b/static/examples/bsi/componenti/card/teaser.html
@@ -151,7 +151,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/carousel/card-articolo.html
+++ b/static/examples/bsi/componenti/carousel/card-articolo.html
@@ -217,7 +217,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/carousel/card-con-immagine-in-alto.html
+++ b/static/examples/bsi/componenti/carousel/card-con-immagine-in-alto.html
@@ -257,7 +257,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/carousel/card-con-immagine-in-evidenza.html
+++ b/static/examples/bsi/componenti/carousel/card-con-immagine-in-evidenza.html
@@ -221,7 +221,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/carousel/card-speciali.html
+++ b/static/examples/bsi/componenti/carousel/card-speciali.html
@@ -239,7 +239,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/carousel/immagini-di-dimensione-standard.html
+++ b/static/examples/bsi/componenti/carousel/immagini-di-dimensione-standard.html
@@ -203,7 +203,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/carousel/immagini.html
+++ b/static/examples/bsi/componenti/carousel/immagini.html
@@ -203,7 +203,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/carousel/titolo-e-card-base.html
+++ b/static/examples/bsi/componenti/carousel/titolo-e-card-base.html
@@ -237,7 +237,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/chips/disabilitata.html
+++ b/static/examples/bsi/componenti/chips/disabilitata.html
@@ -149,7 +149,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/chips/gruppi.html
+++ b/static/examples/bsi/componenti/chips/gruppi.html
@@ -183,7 +183,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/chips/standard-e-grandi.html
+++ b/static/examples/bsi/componenti/chips/standard-e-grandi.html
@@ -189,7 +189,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/chips/varianti-di-colore.html
+++ b/static/examples/bsi/componenti/chips/varianti-di-colore.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/collapse/attivazione-elementi-richiudibili.html
+++ b/static/examples/bsi/componenti/collapse/attivazione-elementi-richiudibili.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/collapse/base.html
+++ b/static/examples/bsi/componenti/collapse/base.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dimmer/base-default-disattivato.html
+++ b/static/examples/bsi/componenti/dimmer/base-default-disattivato.html
@@ -173,7 +173,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dimmer/base.html
+++ b/static/examples/bsi/componenti/dimmer/base.html
@@ -172,7 +172,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dimmer/colore-primary.html
+++ b/static/examples/bsi/componenti/dimmer/colore-primary.html
@@ -170,7 +170,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dimmer/con-azioni-colore-primary.html
+++ b/static/examples/bsi/componenti/dimmer/con-azioni-colore-primary.html
@@ -173,7 +173,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dimmer/con-azioni.html
+++ b/static/examples/bsi/componenti/dimmer/con-azioni.html
@@ -174,7 +174,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/base-con-pulsante.html
+++ b/static/examples/bsi/componenti/dropdown/base-con-pulsante.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/con-varianti-di-pulsanti.html
+++ b/static/examples/bsi/componenti/dropdown/con-varianti-di-pulsanti.html
@@ -164,7 +164,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/dropend-si-apre-a-destra.html
+++ b/static/examples/bsi/componenti/dropdown/dropend-si-apre-a-destra.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/dropstart-si-apre-a-sinistra.html
+++ b/static/examples/bsi/componenti/dropdown/dropstart-si-apre-a-sinistra.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/dropup-si-apre-verso-l'alto.html
+++ b/static/examples/bsi/componenti/dropdown/dropup-si-apre-verso-l'alto.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/link.html
+++ b/static/examples/bsi/componenti/dropdown/link.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-a-tutta-larghezza.html
+++ b/static/examples/bsi/componenti/dropdown/menu-a-tutta-larghezza.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-con-icona-a-destra.html
+++ b/static/examples/bsi/componenti/dropdown/menu-con-icona-a-destra.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-con-icona-a-sinistra.html
+++ b/static/examples/bsi/componenti/dropdown/menu-con-icona-a-sinistra.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-con-instestazioni-e-separatori.html
+++ b/static/examples/bsi/componenti/dropdown/menu-con-instestazioni-e-separatori.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.6.2/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-con-intestazioni-e-separatori.html
+++ b/static/examples/bsi/componenti/dropdown/menu-con-intestazioni-e-separatori.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-con-voci-grandi.html
+++ b/static/examples/bsi/componenti/dropdown/menu-con-voci-grandi.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-dark.html
+++ b/static/examples/bsi/componenti/dropdown/menu-dark.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-voci-attive.html
+++ b/static/examples/bsi/componenti/dropdown/menu-voci-attive.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/dropdown/menu-voci-disabilitate.html
+++ b/static/examples/bsi/componenti/dropdown/menu-voci-disabilitate.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/forward/base.html
+++ b/static/examples/bsi/componenti/forward/base.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-immagine-e-margine-negativo.html
+++ b/static/examples/bsi/componenti/hero/con-immagine-e-margine-negativo.html
@@ -162,7 +162,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-immagine-piccolo.html
+++ b/static/examples/bsi/componenti/hero/con-immagine-piccolo.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-immagine.html
+++ b/static/examples/bsi/componenti/hero/con-immagine.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-overlay-di-colore-primary.html
+++ b/static/examples/bsi/componenti/hero/con-overlay-di-colore-primary.html
@@ -139,7 +139,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-overlay-e-filtro-di-colore-primary.html
+++ b/static/examples/bsi/componenti/hero/con-overlay-e-filtro-di-colore-primary.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-testo-centrato.html
+++ b/static/examples/bsi/componenti/hero/con-testo-centrato.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-testo-e-immagine-di-sfondo.html
+++ b/static/examples/bsi/componenti/hero/con-testo-e-immagine-di-sfondo.html
@@ -139,7 +139,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/hero/con-testo.html
+++ b/static/examples/bsi/componenti/hero/con-testo.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/componenti-della-modale.html
+++ b/static/examples/bsi/componenti/modale/componenti-della-modale.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/con-elementi-form.html
+++ b/static/examples/bsi/componenti/modale/con-elementi-form.html
@@ -151,7 +151,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/con-icona.html
+++ b/static/examples/bsi/componenti/modale/con-icona.html
@@ -138,7 +138,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/con-lista-link.html
+++ b/static/examples/bsi/componenti/modale/con-lista-link.html
@@ -159,7 +159,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/con-pulsante-di-chiusura.html
+++ b/static/examples/bsi/componenti/modale/con-pulsante-di-chiusura.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/demo-allineata-a-destra.html
+++ b/static/examples/bsi/componenti/modale/demo-allineata-a-destra.html
@@ -164,7 +164,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/demo-allineata-a-sinistra.html
+++ b/static/examples/bsi/componenti/modale/demo-allineata-a-sinistra.html
@@ -164,7 +164,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/demo-base.html
+++ b/static/examples/bsi/componenti/modale/demo-base.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/demo-centrata-in-verticale.html
+++ b/static/examples/bsi/componenti/modale/demo-centrata-in-verticale.html
@@ -142,7 +142,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/demo-con-contenuti-lunghi-scroll-interno.html
+++ b/static/examples/bsi/componenti/modale/demo-con-contenuti-lunghi-scroll-interno.html
@@ -160,7 +160,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/demo-con-contenuti-lunghi.html
+++ b/static/examples/bsi/componenti/modale/demo-con-contenuti-lunghi.html
@@ -165,7 +165,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/popconfirm.html
+++ b/static/examples/bsi/componenti/modale/popconfirm.html
@@ -159,7 +159,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/pulsante-di-chiusura-dettaglio.html
+++ b/static/examples/bsi/componenti/modale/pulsante-di-chiusura-dettaglio.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/modale/varianti-di-dimensione.html
+++ b/static/examples/bsi/componenti/modale/varianti-di-dimensione.html
@@ -165,7 +165,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/notifiche/base-con-o-senza-icona.html
+++ b/static/examples/bsi/componenti/notifiche/base-con-o-senza-icona.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/notifiche/con-messaggio.html
+++ b/static/examples/bsi/componenti/notifiche/con-messaggio.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/notifiche/eliminabili.html
+++ b/static/examples/bsi/componenti/notifiche/eliminabili.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/notifiche/posizione-e-arrotondamento.html
+++ b/static/examples/bsi/componenti/notifiche/posizione-e-arrotondamento.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/notifiche/posizione-fissa.html
+++ b/static/examples/bsi/componenti/notifiche/posizione-fissa.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/notifiche/posizione-predefinita.html
+++ b/static/examples/bsi/componenti/notifiche/posizione-predefinita.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/notifiche/varianti-di-stato.html
+++ b/static/examples/bsi/componenti/notifiche/varianti-di-stato.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/overlay/colore-nero.html
+++ b/static/examples/bsi/componenti/overlay/colore-nero.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/overlay/colore-primary.html
+++ b/static/examples/bsi/componenti/overlay/colore-primary.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/overlay/con-icona.html
+++ b/static/examples/bsi/componenti/overlay/con-icona.html
@@ -142,7 +142,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/base.html
+++ b/static/examples/bsi/componenti/paginazione/base.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/con-funzionalita-cambia-pagina.html
+++ b/static/examples/bsi/componenti/paginazione/con-funzionalita-cambia-pagina.html
@@ -164,7 +164,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/con-funzionalita-piu.html
+++ b/static/examples/bsi/componenti/paginazione/con-funzionalita-piu.html
@@ -151,7 +151,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/con-funzionalita-salta-alla-pagina.html
+++ b/static/examples/bsi/componenti/paginazione/con-funzionalita-salta-alla-pagina.html
@@ -151,7 +151,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/con-link-testuali.html
+++ b/static/examples/bsi/componenti/paginazione/con-link-testuali.html
@@ -141,7 +141,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/con-numero-totale-elementi-per-pagina.html
+++ b/static/examples/bsi/componenti/paginazione/con-numero-totale-elementi-per-pagina.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/con-numero-totale-elementi.html
+++ b/static/examples/bsi/componenti/paginazione/con-numero-totale-elementi.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/con-stato-disabilitato.html
+++ b/static/examples/bsi/componenti/paginazione/con-stato-disabilitato.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/modalita-semplificata-mobile.html
+++ b/static/examples/bsi/componenti/paginazione/modalita-semplificata-mobile.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/navigazione-a-destra.html
+++ b/static/examples/bsi/componenti/paginazione/navigazione-a-destra.html
@@ -141,7 +141,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/navigazione-centrata.html
+++ b/static/examples/bsi/componenti/paginazione/navigazione-centrata.html
@@ -141,7 +141,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/paginazione/navigazione-responsive.html
+++ b/static/examples/bsi/componenti/paginazione/navigazione-responsive.html
@@ -151,7 +151,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/popover/base.html
+++ b/static/examples/bsi/componenti/popover/base.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/popover/con-chiusura-al-click-successivo.html
+++ b/static/examples/bsi/componenti/popover/con-chiusura-al-click-successivo.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/popover/con-icona-e-link.html
+++ b/static/examples/bsi/componenti/popover/con-icona-e-link.html
@@ -121,7 +121,7 @@ Popover con icona e link
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/popover/modalita-hover.html
+++ b/static/examples/bsi/componenti/popover/modalita-hover.html
@@ -121,7 +121,7 @@ Apertura in Hover
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/popover/per-elementi-disabilitati.html
+++ b/static/examples/bsi/componenti/popover/per-elementi-disabilitati.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/popover/varianti-di-allineamento.html
+++ b/static/examples/bsi/componenti/popover/varianti-di-allineamento.html
@@ -151,7 +151,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/barra-di-progresso-con-etichetta.html
+++ b/static/examples/bsi/componenti/progress-indicators/barra-di-progresso-con-etichetta.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/barra-di-progresso-varianti-di-colore.html
+++ b/static/examples/bsi/componenti/progress-indicators/barra-di-progresso-varianti-di-colore.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/barra-di-progresso.html
+++ b/static/examples/bsi/componenti/progress-indicators/barra-di-progresso.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/ciambelle.html
+++ b/static/examples/bsi/componenti/progress-indicators/ciambelle.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/progresso-indeterminato.html
+++ b/static/examples/bsi/componenti/progress-indicators/progresso-indeterminato.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/progresso-intederminato.html
+++ b/static/examples/bsi/componenti/progress-indicators/progresso-intederminato.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.6.2/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/pulsante-con-barra-di-progresso.html
+++ b/static/examples/bsi/componenti/progress-indicators/pulsante-con-barra-di-progresso.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/spinner-animazione-alternativa.html
+++ b/static/examples/bsi/componenti/progress-indicators/spinner-animazione-alternativa.html
@@ -188,7 +188,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/progress-indicators/spinner.html
+++ b/static/examples/bsi/componenti/progress-indicators/spinner.html
@@ -172,7 +172,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/rating/base.html
+++ b/static/examples/bsi/componenti/rating/base.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/rating/con-etichetta.html
+++ b/static/examples/bsi/componenti/rating/con-etichetta.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/rating/sola-lettura.html
+++ b/static/examples/bsi/componenti/rating/sola-lettura.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sections/base.html
+++ b/static/examples/bsi/componenti/sections/base.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sections/con-card.html
+++ b/static/examples/bsi/componenti/sections/con-card.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sections/con-immagine-di-sfondo.html
+++ b/static/examples/bsi/componenti/sections/con-immagine-di-sfondo.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sections/sfondo-neutrale.html
+++ b/static/examples/bsi/componenti/sections/sfondo-neutrale.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sections/sfondo-primario.html
+++ b/static/examples/bsi/componenti/sections/sfondo-primario.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sections/sfondo-tenue.html
+++ b/static/examples/bsi/componenti/sections/sfondo-tenue.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-navigazione-degli-step.html
+++ b/static/examples/bsi/componenti/steppers/con-navigazione-degli-step.html
@@ -138,7 +138,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-navigazione-mobile-barra-di-progresso.html
+++ b/static/examples/bsi/componenti/steppers/con-navigazione-mobile-barra-di-progresso.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-navigazione-mobile-e-pulsante-conferma.html
+++ b/static/examples/bsi/componenti/steppers/con-navigazione-mobile-e-pulsante-conferma.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-navigazione-mobile-e-pulsante-salva.html
+++ b/static/examples/bsi/componenti/steppers/con-navigazione-mobile-e-pulsante-salva.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-navigazione-mobile-pallini.html
+++ b/static/examples/bsi/componenti/steppers/con-navigazione-mobile-pallini.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-barra-di-progresso.html
+++ b/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-barra-di-progresso.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-e-pulsante-conferma.html
+++ b/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-e-pulsante-conferma.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-e-pulsante-salva.html
+++ b/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-e-pulsante-salva.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-pallini.html
+++ b/static/examples/bsi/componenti/steppers/con-sfondo-scuro-navigazione-mobile-pallini.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-sfondo-scuro-varianti-intestazione.html
+++ b/static/examples/bsi/componenti/steppers/con-sfondo-scuro-varianti-intestazione.html
@@ -153,7 +153,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/con-sfondo-scuro.html
+++ b/static/examples/bsi/componenti/steppers/con-sfondo-scuro.html
@@ -138,7 +138,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/intestazione-ordinata.html
+++ b/static/examples/bsi/componenti/steppers/intestazione-ordinata.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/intestazione-solo-testo.html
+++ b/static/examples/bsi/componenti/steppers/intestazione-solo-testo.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/steppers/intestazione-testo-e-icone.html
+++ b/static/examples/bsi/componenti/steppers/intestazione-testo-e-icone.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sticky/attivabile-con-target.html
+++ b/static/examples/bsi/componenti/sticky/attivabile-con-target.html
@@ -205,7 +205,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sticky/base.html
+++ b/static/examples/bsi/componenti/sticky/base.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sticky/con-posizione-fissa.html
+++ b/static/examples/bsi/componenti/sticky/con-posizione-fissa.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/sticky/variante-impilabile.html
+++ b/static/examples/bsi/componenti/sticky/variante-impilabile.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-icona-grande.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-icona-grande.html
@@ -150,7 +150,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-markup-alternativo.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-markup-alternativo.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-orizzontale-in-basso.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-orizzontale-in-basso.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-orizzontale-a-tutta-larghezza-testo-e-icona.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-orizzontale-a-tutta-larghezza-testo-e-icona.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-orizzontale-a-tutta-larghezza.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-orizzontale-a-tutta-larghezza.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-verticale-a-destra.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-verticale-a-destra.html
@@ -138,7 +138,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-verticale-a-sinistra.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-sfondo-scuro-verticale-a-sinistra.html
@@ -138,7 +138,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-testo-e-icona.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-testo-e-icona.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-testuali.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-testuali.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-tipo-card-con-pulsanti-aggiungielimina.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-tipo-card-con-pulsanti-aggiungielimina.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-tipo-card.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-tipo-card.html
@@ -131,7 +131,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-a-destra.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-a-destra.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-colore-di-sfondo.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-colore-di-sfondo.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-icona.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-icona.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-testo-e-icona.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-testo-e-icona.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-testuale.html
+++ b/static/examples/bsi/componenti/tab/con-controllo-pannelli-verticale-testuale.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-con-icona-grande.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-con-icona-grande.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-con-icona.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-con-icona.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-con-testo-e-icona.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-con-testo-e-icona.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-testuali.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-a-tutta-larghezza-testuali.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-con-icona-grande.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-con-icona-grande.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-con-icona.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-con-icona.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-con-testo-e-icona.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-con-testo-e-icona.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/orizzontali-testuali.html
+++ b/static/examples/bsi/componenti/tab/orizzontali-testuali.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tab/senza-scrollbar-su-mobile.html
+++ b/static/examples/bsi/componenti/tab/senza-scrollbar-su-mobile.html
@@ -178,7 +178,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/timeline/base-verticale.html
+++ b/static/examples/bsi/componenti/timeline/base-verticale.html
@@ -330,7 +330,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/toasts/toasts-1.html
+++ b/static/examples/bsi/componenti/toasts/toasts-1.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/toasts/toasts-2.html
+++ b/static/examples/bsi/componenti/toasts/toasts-2.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/toasts/toasts-3.html
+++ b/static/examples/bsi/componenti/toasts/toasts-3.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/toasts/toasts-4.html
+++ b/static/examples/bsi/componenti/toasts/toasts-4.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/toasts/toasts-5.html
+++ b/static/examples/bsi/componenti/toasts/toasts-5.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/toasts/toasts-6.html
+++ b/static/examples/bsi/componenti/toasts/toasts-6.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/toasts/toasts-7.html
+++ b/static/examples/bsi/componenti/toasts/toasts-7.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tooltip/esempi.html
+++ b/static/examples/bsi/componenti/tooltip/esempi.html
@@ -137,7 +137,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/tooltip/varianti-di-allineamento.html
+++ b/static/examples/bsi/componenti/tooltip/varianti-di-allineamento.html
@@ -153,7 +153,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/video-player/base.html
+++ b/static/examples/bsi/componenti/video-player/base.html
@@ -138,7 +138,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/video-player/con-configurazione-iniziale.html
+++ b/static/examples/bsi/componenti/video-player/con-configurazione-iniziale.html
@@ -145,7 +145,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/video-player/con-didascalie-in-piu-lingue.html
+++ b/static/examples/bsi/componenti/video-player/con-didascalie-in-piu-lingue.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/video-player/con-overlay-di-consenso-cookie-(youtube).html
+++ b/static/examples/bsi/componenti/video-player/con-overlay-di-consenso-cookie-(youtube).html
@@ -164,7 +164,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/video-player/con-video-e-piu-tracce-audio-hls-multilingua.html
+++ b/static/examples/bsi/componenti/video-player/con-video-e-piu-tracce-audio-hls-multilingua.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/componenti/video-player/con-video-in-streaming-in-formato-mpeg-dash.html
+++ b/static/examples/bsi/componenti/video-player/con-video-in-streaming-in-formato-mpeg-dash.html
@@ -176,7 +176,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/autocompletamento/base.html
+++ b/static/examples/bsi/form/autocompletamento/base.html
@@ -246,7 +246,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/checkbox/base.html
+++ b/static/examples/bsi/form/checkbox/base.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/checkbox/con-stato-mixed.html
+++ b/static/examples/bsi/form/checkbox/con-stato-mixed.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/checkbox/disabilitato.html
+++ b/static/examples/bsi/form/checkbox/disabilitato.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/checkbox/gruppi.html
+++ b/static/examples/bsi/form/checkbox/gruppi.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/checkbox/in-linea.html
+++ b/static/examples/bsi/form/checkbox/in-linea.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-calendario/base.html
+++ b/static/examples/bsi/form/input-calendario/base.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-numerico/base.html
+++ b/static/examples/bsi/form/input-numerico/base.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-numerico/con-limiti-e-incremento.html
+++ b/static/examples/bsi/form/input-numerico/con-limiti-e-incremento.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-numerico/con-percentuale.html
+++ b/static/examples/bsi/form/input-numerico/con-percentuale.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-numerico/con-ridimensionamento.html
+++ b/static/examples/bsi/form/input-numerico/con-ridimensionamento.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-numerico/con-valuta.html
+++ b/static/examples/bsi/form/input-numerico/con-valuta.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-numerico/disabilitato.html
+++ b/static/examples/bsi/form/input-numerico/disabilitato.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input-ora/base.html
+++ b/static/examples/bsi/form/input-ora/base.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/area-di-testo.html
+++ b/static/examples/bsi/form/input/area-di-testo.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/con-etichetta-e-segnaposto.html
+++ b/static/examples/bsi/form/input/con-etichetta-e-segnaposto.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/con-etichetta.html
+++ b/static/examples/bsi/form/input/con-etichetta.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/con-testo-di-aiuto.html
+++ b/static/examples/bsi/form/input/con-testo-di-aiuto.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/disabilitato.html
+++ b/static/examples/bsi/form/input/disabilitato.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/password.html
+++ b/static/examples/bsi/form/input/password.html
@@ -155,7 +155,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/ricerca-con-autocompletamento-e-dati-cerca-una-nazione.html
+++ b/static/examples/bsi/form/input/ricerca-con-autocompletamento-e-dati-cerca-una-nazione.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/ricerca-con-autocompletamento-e-dati-cerca-una-regione-italiana.html
+++ b/static/examples/bsi/form/input/ricerca-con-autocompletamento-e-dati-cerca-una-regione-italiana.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/ricerca-con-autocompletamento-grande.html
+++ b/static/examples/bsi/form/input/ricerca-con-autocompletamento-grande.html
@@ -166,7 +166,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/ricerca-con-autocompletamento.html
+++ b/static/examples/bsi/form/input/ricerca-con-autocompletamento.html
@@ -181,7 +181,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/solo-lettura-normalizzato.html
+++ b/static/examples/bsi/form/input/solo-lettura-normalizzato.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/solo-lettura.html
+++ b/static/examples/bsi/form/input/solo-lettura.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/varianti-con-icona-o-pulsanti.html
+++ b/static/examples/bsi/form/input/varianti-con-icona-o-pulsanti.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/varianti-di-dimensione.html
+++ b/static/examples/bsi/form/input/varianti-di-dimensione.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/input/varianti-per-tipo.html
+++ b/static/examples/bsi/form/input/varianti-per-tipo.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/introduzione/auto-dimensionamento.html
+++ b/static/examples/bsi/form/introduzione/auto-dimensionamento.html
@@ -144,7 +144,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/introduzione/campo-input-disabilitato.html
+++ b/static/examples/bsi/form/introduzione/campo-input-disabilitato.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/introduzione/con-sistema-a-griglie.html
+++ b/static/examples/bsi/form/introduzione/con-sistema-a-griglie.html
@@ -179,7 +179,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/introduzione/con-validazione.html
+++ b/static/examples/bsi/form/introduzione/con-validazione.html
@@ -256,7 +256,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/introduzione/dimensionamento-colonne.html
+++ b/static/examples/bsi/form/introduzione/dimensionamento-colonne.html
@@ -144,7 +144,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/introduzione/form-disabilitato.html
+++ b/static/examples/bsi/form/introduzione/form-disabilitato.html
@@ -176,7 +176,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/radio-button/base.html
+++ b/static/examples/bsi/form/radio-button/base.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/radio-button/disabilitato.html
+++ b/static/examples/bsi/form/radio-button/disabilitato.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/radio-button/gruppi.html
+++ b/static/examples/bsi/form/radio-button/gruppi.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/radio-button/in-linea.html
+++ b/static/examples/bsi/form/radio-button/in-linea.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/select/base.html
+++ b/static/examples/bsi/form/select/base.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/select/con-gruppi.html
+++ b/static/examples/bsi/form/select/con-gruppi.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/select/disabilitata.html
+++ b/static/examples/bsi/form/select/disabilitata.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/toggles/base.html
+++ b/static/examples/bsi/form/toggles/base.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/toggles/disabilitato.html
+++ b/static/examples/bsi/form/toggles/disabilitato.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/toggles/gruppi.html
+++ b/static/examples/bsi/form/toggles/gruppi.html
@@ -184,7 +184,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/transfer/base.html
+++ b/static/examples/bsi/form/transfer/base.html
@@ -285,7 +285,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/upload/con-animazione.html
+++ b/static/examples/bsi/form/upload/con-animazione.html
@@ -170,7 +170,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/upload/con-anteprima-delle-immagini.html
+++ b/static/examples/bsi/form/upload/con-anteprima-delle-immagini.html
@@ -182,7 +182,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/upload/con-avatar.html
+++ b/static/examples/bsi/form/upload/con-avatar.html
@@ -160,7 +160,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/upload/con-lista-di-file.html
+++ b/static/examples/bsi/form/upload/con-lista-di-file.html
@@ -174,7 +174,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/upload/galleria.html
+++ b/static/examples/bsi/form/upload/galleria.html
@@ -155,7 +155,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/form/upload/trascina-e-rilascia.html
+++ b/static/examples/bsi/form/upload/trascina-e-rilascia.html
@@ -182,7 +182,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/bottomnav/base-con-4-link.html
+++ b/static/examples/bsi/menu-di-navigazione/bottomnav/base-con-4-link.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/bottomnav/base.html
+++ b/static/examples/bsi/menu-di-navigazione/bottomnav/base.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/bottomnav/con-alert.html
+++ b/static/examples/bsi/menu-di-navigazione/bottomnav/con-alert.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/bottomnav/con-badge.html
+++ b/static/examples/bsi/menu-di-navigazione/bottomnav/con-badge.html
@@ -155,7 +155,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/breadcrumbs/base.html
+++ b/static/examples/bsi/menu-di-navigazione/breadcrumbs/base.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/breadcrumbs/con-icona.html
+++ b/static/examples/bsi/menu-di-navigazione/breadcrumbs/con-icona.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/breadcrumbs/con-sfondo-scuro.html
+++ b/static/examples/bsi/menu-di-navigazione/breadcrumbs/con-sfondo-scuro.html
@@ -134,7 +134,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/footer/compatto.html
+++ b/static/examples/bsi/menu-di-navigazione/footer/compatto.html
@@ -193,7 +193,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/footer/completo.html
+++ b/static/examples/bsi/menu-di-navigazione/footer/completo.html
@@ -252,7 +252,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/footer/footer-1.html
+++ b/static/examples/bsi/menu-di-navigazione/footer/footer-1.html
@@ -252,7 +252,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.3/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/footer/footer-2.html
+++ b/static/examples/bsi/menu-di-navigazione/footer/footer-2.html
@@ -193,7 +193,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.3/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-centrale-variante-chiara.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-centrale-variante-chiara.html
@@ -175,7 +175,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-centrale-variante-compatta.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-centrale-variante-compatta.html
@@ -175,7 +175,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-centrale.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-centrale.html
@@ -175,7 +175,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-completa-variante-chiara.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-completa-variante-chiara.html
@@ -333,7 +333,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-completa.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-completa.html
@@ -334,7 +334,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-navigazione-desktop-chiara.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-navigazione-desktop-chiara.html
@@ -219,7 +219,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-navigazione-mobile-scura.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-navigazione-mobile-scura.html
@@ -219,7 +219,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-navigazione-secondaria.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-navigazione-secondaria.html
@@ -159,7 +159,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-navigazione-standard.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-navigazione-standard.html
@@ -219,7 +219,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/header-navigazione.html
+++ b/static/examples/bsi/menu-di-navigazione/header/header-navigazione.html
@@ -219,7 +219,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/slim-header-con-pulsante-accedi-full-responsive.html
+++ b/static/examples/bsi/menu-di-navigazione/header/slim-header-con-pulsante-accedi-full-responsive.html
@@ -160,7 +160,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/slim-header-variante-chiara.html
+++ b/static/examples/bsi/menu-di-navigazione/header/slim-header-variante-chiara.html
@@ -171,7 +171,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/header/slim-header.html
+++ b/static/examples/bsi/menu-di-navigazione/header/slim-header.html
@@ -172,7 +172,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/base.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/base.html
@@ -188,7 +188,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-call-to-action-a-destra.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-call-to-action-a-destra.html
@@ -216,7 +216,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-call-to-action-in-basso.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-call-to-action-in-basso.html
@@ -216,7 +216,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-colonne-asimmetriche-e-call-to-action-a-destra.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-colonne-asimmetriche-e-call-to-action-a-destra.html
@@ -228,7 +228,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-colonne-asimmetriche.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-colonne-asimmetriche.html
@@ -206,7 +206,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-immagine-e-descrizione.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-immagine-e-descrizione.html
@@ -238,7 +238,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-link-vedi-tutti.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-link-vedi-tutti.html
@@ -216,7 +216,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-sezioni-e-link-vedi-tutti.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-sezioni-e-link-vedi-tutti.html
@@ -218,7 +218,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/megamenu/con-sezioni.html
+++ b/static/examples/bsi/menu-di-navigazione/megamenu/con-sezioni.html
@@ -191,7 +191,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/navscroll/con-barra-progresso.html
+++ b/static/examples/bsi/menu-di-navigazione/navscroll/con-barra-progresso.html
@@ -185,7 +185,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/navscroll/menu-in-linea.html
+++ b/static/examples/bsi/menu-di-navigazione/navscroll/menu-in-linea.html
@@ -172,7 +172,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/navscroll/posizionata-a-fondo-pagina-con-linea-a-sinistra.html
+++ b/static/examples/bsi/menu-di-navigazione/navscroll/posizionata-a-fondo-pagina-con-linea-a-sinistra.html
@@ -178,7 +178,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/navscroll/posizionata-in-testa-pagina-con-linea-a-destra.html
+++ b/static/examples/bsi/menu-di-navigazione/navscroll/posizionata-in-testa-pagina-con-linea-a-destra.html
@@ -173,7 +173,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/navscroll/variante-scura.html
+++ b/static/examples/bsi/menu-di-navigazione/navscroll/variante-scura.html
@@ -173,7 +173,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/sidebar/annidata.html
+++ b/static/examples/bsi/menu-di-navigazione/sidebar/annidata.html
@@ -187,7 +187,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/sidebar/base.html
+++ b/static/examples/bsi/menu-di-navigazione/sidebar/base.html
@@ -149,7 +149,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/sidebar/con-icona.html
+++ b/static/examples/bsi/menu-di-navigazione/sidebar/con-icona.html
@@ -169,7 +169,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/sidebar/con-linea-a-destra.html
+++ b/static/examples/bsi/menu-di-navigazione/sidebar/con-linea-a-destra.html
@@ -149,7 +149,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/sidebar/con-linea-a-sinistra.html
+++ b/static/examples/bsi/menu-di-navigazione/sidebar/con-linea-a-sinistra.html
@@ -149,7 +149,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/sidebar/con-sfondo-scuro.html
+++ b/static/examples/bsi/menu-di-navigazione/sidebar/con-sfondo-scuro.html
@@ -184,7 +184,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/skiplinks/base.html
+++ b/static/examples/bsi/menu-di-navigazione/skiplinks/base.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/base.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/base.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/con-hover-con-livello-nero.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/con-hover-con-livello-nero.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/con-hover-con-livello-primary.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/con-hover-con-livello-primary.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/con-hover-senza-ingrandimento.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/con-hover-senza-ingrandimento.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/griglia-a-larghezza-automatica-eg.-1.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/griglia-a-larghezza-automatica-eg.-1.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/griglia-a-larghezza-automatica-eg.-2.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/griglia-a-larghezza-automatica-eg.-2.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/griglia-a-larghezza-fissa.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/griglia-a-larghezza-fissa.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-orizzontale-in-alto.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-orizzontale-in-alto.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-orizzontale-in-basso.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-orizzontale-in-basso.html
@@ -132,7 +132,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-verticale-a-destra.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-verticale-a-destra.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-verticale-a-sinistra.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/overlay-verticale-a-sinistra.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/variante-compatta.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/variante-compatta.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/thumbnav/verticale.html
+++ b/static/examples/bsi/menu-di-navigazione/thumbnav/verticale.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/con-divisori.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/con-divisori.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/grande-con-badge.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/grande-con-badge.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/grande-con-dropdown.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/grande-con-dropdown.html
@@ -209,7 +209,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/grande-verticale.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/grande-verticale.html
@@ -166,7 +166,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/grande.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/grande.html
@@ -152,7 +152,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/media-con-badge.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/media-con-badge.html
@@ -166,7 +166,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/media-con-dropdown.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/media-con-dropdown.html
@@ -232,7 +232,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/media-verticale.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/media-verticale.html
@@ -172,7 +172,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/media.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/media.html
@@ -158,7 +158,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/piccola-con-badge.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/piccola-con-badge.html
@@ -166,7 +166,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/piccola-con-dropdown.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/piccola-con-dropdown.html
@@ -232,7 +232,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/piccola-verticale.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/piccola-verticale.html
@@ -178,7 +178,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/toolbar/piccola.html
+++ b/static/examples/bsi/menu-di-navigazione/toolbar/piccola.html
@@ -158,7 +158,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-indietro/link.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-indietro/link.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-indietro/pulsanti-con-freccia.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-indietro/pulsanti-con-freccia.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-indietro/pulsanti-solo-icona.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-indietro/pulsanti-solo-icona.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-su/base-esempio.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-su/base-esempio.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-su/base-funzionante.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-su/base-funzionante.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-su/compatto-esempio.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-su/compatto-esempio.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-su/con-ombra-esempio.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-su/con-ombra-esempio.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-su/con-ombra-per-sfondo-scuro-esempio.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-su/con-ombra-per-sfondo-scuro-esempio.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/menu-di-navigazione/torna-su/per-sfondo-scuro-esempio.html
+++ b/static/examples/bsi/menu-di-navigazione/torna-su/per-sfondo-scuro-esempio.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/allineamento-verticale/con-celle-di-tabella.html
+++ b/static/examples/bsi/organizzare-gli-spazi/allineamento-verticale/con-celle-di-tabella.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/allineamento-verticale/con-elementi-inline.html
+++ b/static/examples/bsi/organizzare-gli-spazi/allineamento-verticale/con-elementi-inline.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/bordi/aggiuntivo.html
+++ b/static/examples/bsi/organizzare-gli-spazi/bordi/aggiuntivo.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/bordi/arrotondati.html
+++ b/static/examples/bsi/organizzare-gli-spazi/bordi/arrotondati.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/bordi/bordi-2.html
+++ b/static/examples/bsi/organizzare-gli-spazi/bordi/bordi-2.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.6.1/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/bordi/sottrattivo.html
+++ b/static/examples/bsi/organizzare-gli-spazi/bordi/sottrattivo.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/bordi/varianti-di-colore.html
+++ b/static/examples/bsi/organizzare-gli-spazi/bordi/varianti-di-colore.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/clearfix/base.html
+++ b/static/examples/bsi/organizzare-gli-spazi/clearfix/base.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/dimensionamento/altezza-fissa.html
+++ b/static/examples/bsi/organizzare-gli-spazi/dimensionamento/altezza-fissa.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/dimensionamento/altezza-massima.html
+++ b/static/examples/bsi/organizzare-gli-spazi/dimensionamento/altezza-massima.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/dimensionamento/larghezza-fissa.html
+++ b/static/examples/bsi/organizzare-gli-spazi/dimensionamento/larghezza-fissa.html
@@ -124,7 +124,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/dimensionamento/larghezza-massima.html
+++ b/static/examples/bsi/organizzare-gli-spazi/dimensionamento/larghezza-massima.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/display/block.html
+++ b/static/examples/bsi/organizzare-gli-spazi/display/block.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/display/inline.html
+++ b/static/examples/bsi/organizzare-gli-spazi/display/inline.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/display/responsive.html
+++ b/static/examples/bsi/organizzare-gli-spazi/display/responsive.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/display/stampa.html
+++ b/static/examples/bsi/organizzare-gli-spazi/display/stampa.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/align-content-around.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/align-content-around.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/align-content-between.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/align-content-between.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/align-content-center.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/align-content-center.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/align-content-end.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/align-content-end.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/align-content-start.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/align-content-start.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/align-content-stretch.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/align-content-stretch.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/allineamento-elementi.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/allineamento-elementi.html
@@ -144,7 +144,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/auto-allineamento.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/auto-allineamento.html
@@ -144,7 +144,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/con-elementi-spostati-in-cima-o-in-fondo.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/con-elementi-spostati-in-cima-o-in-fondo.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/contenuto-giustificato.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/contenuto-giustificato.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/flexbox.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/flexbox.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/inline-flexbox.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/inline-flexbox.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/margini-automatici.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/margini-automatici.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/no-wrap.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/no-wrap.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/ordinamento.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/ordinamento.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/varianti-di-direzione-verticale.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/varianti-di-direzione-verticale.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/varianti-di-direzione.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/varianti-di-direzione.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/wrap-reverse.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/wrap-reverse.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/flex/wrap.html
+++ b/static/examples/bsi/organizzare-gli-spazi/flex/wrap.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/float/varianti-responsive.html
+++ b/static/examples/bsi/organizzare-gli-spazi/float/varianti-responsive.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/float/varianti-start-end-none.html
+++ b/static/examples/bsi/organizzare-gli-spazi/float/varianti-start-end-none.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/allineamento-orizzontale.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/allineamento-orizzontale.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/allineamento-verticale-misto.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/allineamento-verticale-misto.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/allineamento-verticale.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/allineamento-verticale.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/annidamento.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/annidamento.html
@@ -127,7 +127,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/base.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/base.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/colonna-a-capo.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/colonna-a-capo.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/colonne-con-larghezze-omogenee-alternativa.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/colonne-con-larghezze-omogenee-alternativa.html
@@ -127,7 +127,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/colonne-con-larghezze-omogenee.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/colonne-con-larghezze-omogenee.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/contenuto-a-larghezza-variabile.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/contenuto-a-larghezza-variabile.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/gutter-variabile.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/gutter-variabile.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/impostare-la-larghezza-di-una-colonna.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/impostare-la-larghezza-di-una-colonna.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/interruzione-di-colonna-responsive.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/interruzione-di-colonna-responsive.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/interruzione-di-colonna.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/interruzione-di-colonna.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/larghezza-identica-su-piu-righe.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/larghezza-identica-su-piu-righe.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/margini-forzati-tra-colonne-adiacenti.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/margini-forzati-tra-colonne-adiacenti.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/offset-responsive.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/offset-responsive.html
@@ -127,7 +127,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/offset.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/offset.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-mischiare-e-abbinare.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-mischiare-e-abbinare.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-per-tutti-i-breakpoint.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-per-tutti-i-breakpoint.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-raccolti-in-orizzontale.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-raccolti-in-orizzontale.html
@@ -127,7 +127,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-1.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-1.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-2.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-2.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-3.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-3.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-4.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-4.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-5.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/responsive-righe-di-colonne-eg.-5.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/riordinamento-first-e-last.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/riordinamento-first-e-last.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/riordinamento.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/riordinamento.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/griglie/senza-gutter.html
+++ b/static/examples/bsi/organizzare-gli-spazi/griglie/senza-gutter.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/ombreggiature/varianti-di-profondita.html
+++ b/static/examples/bsi/organizzare-gli-spazi/ombreggiature/varianti-di-profondita.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/proporzioni/esempio-proporzione-16x9.html
+++ b/static/examples/bsi/organizzare-gli-spazi/proporzioni/esempio-proporzione-16x9.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/proporzioni/proporzione-personalizzata-responsive.html
+++ b/static/examples/bsi/organizzare-gli-spazi/proporzioni/proporzione-personalizzata-responsive.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/proporzioni/proporzione-personalizzata.html
+++ b/static/examples/bsi/organizzare-gli-spazi/proporzioni/proporzione-personalizzata.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/proporzioni/varianti-di-proporzioni.html
+++ b/static/examples/bsi/organizzare-gli-spazi/proporzioni/varianti-di-proporzioni.html
@@ -130,7 +130,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-gli-spazi/spaziature/centratura-orizzontale.html
+++ b/static/examples/bsi/organizzare-gli-spazi/spaziature/centratura-orizzontale.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/codice/blocchi-di-codice.html
+++ b/static/examples/bsi/organizzare-i-contenuti/codice/blocchi-di-codice.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/codice/codice-inline.html
+++ b/static/examples/bsi/organizzare-i-contenuti/codice/codice-inline.html
@@ -119,7 +119,7 @@ Per esempio, <code>&lt;section&gt;</code> dovrebbe essere renderizzato come inli
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/codice/input-utente.html
+++ b/static/examples/bsi/organizzare-i-contenuti/codice/input-utente.html
@@ -120,7 +120,7 @@ Per modificare le impostazioni, premi <kbd>ctrl</kbd> + <kbd>i</kbd>.
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/codice/output-di-esempio.html
+++ b/static/examples/bsi/organizzare-i-contenuti/codice/output-di-esempio.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/codice/variabili.html
+++ b/static/examples/bsi/organizzare-i-contenuti/codice/variabili.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini-sostitutive/immagini-sostitutive-1.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini-sostitutive/immagini-sostitutive-1.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini/allineamenti-start-end.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini/allineamenti-start-end.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini/allineamento-centrato-alternativa.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini/allineamento-centrato-alternativa.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini/allineamento-centrato.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini/allineamento-centrato.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini/base.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini/base.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini/figure-con-didascalia-allineata-a-destra.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini/figure-con-didascalia-allineata-a-destra.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini/figure.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini/figure.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/immagini/thumbnail.html
+++ b/static/examples/bsi/organizzare-i-contenuti/immagini/thumbnail.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-masonry.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-masonry.html
@@ -326,7 +326,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-proporzionale.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-proporzionale.html
@@ -194,7 +194,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-standard-con-didascalia.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-standard-con-didascalia.html
@@ -224,7 +224,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-standard.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/griglia-standard.html
@@ -188,7 +188,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/varianti-didascalia.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste-di-immagini/varianti-didascalia.html
@@ -165,7 +165,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/azioni-con-freccia.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/azioni-con-freccia.html
@@ -142,7 +142,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/azioni-multiple.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/azioni-multiple.html
@@ -198,7 +198,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/base-con-avatar.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/base-con-avatar.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/base-con-icona.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/base-con-icona.html
@@ -155,7 +155,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/base-con-immagine.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/base-con-immagine.html
@@ -143,7 +143,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/base-con-testo.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/base-con-testo.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/con-medatada.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/con-medatada.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.6.2/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/con-metadata.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/con-metadata.html
@@ -157,7 +157,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/con-testo-aggiuntivo-azioni-multiple-e-metadata.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/con-testo-aggiuntivo-azioni-multiple-e-metadata.html
@@ -222,7 +222,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/lista-di-link-con-checkbox.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/lista-di-link-con-checkbox.html
@@ -140,7 +140,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/lista-di-link-con-toggle.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/lista-di-link-con-toggle.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-annidata-collassabile.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-annidata-collassabile.html
@@ -170,7 +170,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-annidata-espansa.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-annidata-espansa.html
@@ -154,7 +154,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-base.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-base.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-azioni-primaria-e-secondaria-varianti-posizione-icona.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-azioni-primaria-e-secondaria-varianti-posizione-icona.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-controlli-e-icona-a-destra.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-controlli-e-icona-a-destra.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-controlli-e-icona-a-sinistra.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-controlli-e-icona-a-sinistra.html
@@ -146,7 +146,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-dimensione-grande.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-dimensione-grande.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-intestazione-e-divisore.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-intestazione-e-divisore.html
@@ -138,7 +138,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-intestazione-e-link-e-divisore.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-intestazione-e-link-e-divisore.html
@@ -133,7 +133,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-stato-attivo.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-stato-attivo.html
@@ -131,7 +131,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-stato-disabilitato.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-con-stato-disabilitato.html
@@ -131,7 +131,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-multilinea-con-icona.html
+++ b/static/examples/bsi/organizzare-i-contenuti/liste/per-menu-multilinea-con-icona.html
@@ -155,7 +155,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/allineamenti-verticali.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/allineamenti-verticali.html
@@ -150,7 +150,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/annidamento.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/annidamento.html
@@ -172,7 +172,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/base.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/base.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/celle-colorate.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/celle-colorate.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/compatta.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/compatta.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/con-bordi-varianti-di-colore.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/con-bordi-varianti-di-colore.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/con-bordi.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/con-bordi.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/con-didascalia-al-piede.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/con-didascalia-al-piede.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/con-didascalia-in-alto.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/con-didascalia-in-alto.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/con-piede.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/con-piede.html
@@ -156,7 +156,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/con-stato-attivo.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/con-stato-attivo.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/con-testata-scura.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/con-testata-scura.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/responsive-breakpoint-specifici.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/responsive-breakpoint-specifici.html
@@ -331,7 +331,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/responsive-sempre.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/responsive-sempre.html
@@ -174,7 +174,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-colorate.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-colorate.html
@@ -174,7 +174,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-con-stato-hover.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-con-stato-hover.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-striate-con-stato-hover.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-striate-con-stato-hover.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-striate-sfondo-scuro.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-striate-sfondo-scuro.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-striate.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/righe-striate.html
@@ -148,7 +148,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/senza-bordi-sfondo-scuro.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/senza-bordi-sfondo-scuro.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/senza-bordi.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/senza-bordi.html
@@ -147,7 +147,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tabelle/tabelle-colorate.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tabelle/tabelle-colorate.html
@@ -197,7 +197,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/testo/allineato-a-sinistra.html
+++ b/static/examples/bsi/organizzare-i-contenuti/testo/allineato-a-sinistra.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/testo/con-troncamento-in-punti-di-sospensione.html
+++ b/static/examples/bsi/organizzare-i-contenuti/testo/con-troncamento-in-punti-di-sospensione.html
@@ -129,7 +129,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/testo/monospaziato.html
+++ b/static/examples/bsi/organizzare-i-contenuti/testo/monospaziato.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/testo/per-esteso-e-overflow.html
+++ b/static/examples/bsi/organizzare-i-contenuti/testo/per-esteso-e-overflow.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/testo/stile.html
+++ b/static/examples/bsi/organizzare-i-contenuti/testo/stile.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/testo/trasformazioni.html
+++ b/static/examples/bsi/organizzare-i-contenuti/testo/trasformazioni.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/testo/varianti-di-allineamento.html
+++ b/static/examples/bsi/organizzare-i-contenuti/testo/varianti-di-allineamento.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/abbreviazioni.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/abbreviazioni.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-a-destra.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-a-destra.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-base.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-base.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-card-con-sfondo-scuro.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-card-con-sfondo-scuro.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-card.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-card.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-centrata.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/citazione-centrata.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/citazioni-con-fonte.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/citazioni-con-fonte.html
@@ -122,7 +122,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/citazioni.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/citazioni.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/intestazione-h1-in-evidenza.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/intestazione-h1-in-evidenza.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/intestazioni.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/intestazioni.html
@@ -131,7 +131,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/link.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/link.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/lista-allineamento-descrizione.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/lista-allineamento-descrizione.html
@@ -142,7 +142,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/lista-inline.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/lista-inline.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/lista-senza-stile.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/lista-senza-stile.html
@@ -135,7 +135,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/lora.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/lora.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/markup-semantico-nei-paragrafi.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/markup-semantico-nei-paragrafi.html
@@ -126,7 +126,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/paragrafi-contenuti.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/paragrafi-contenuti.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/paragrafi-in-evidenza.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/paragrafi-in-evidenza.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/roboto.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/roboto.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/tipografia-6.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/tipografia-6.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/organizzare-i-contenuti/tipografia/titillium-web.html
+++ b/static/examples/bsi/organizzare-i-contenuti/tipografia/titillium-web.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/colori-complementari-e-triadici.html
+++ b/static/examples/bsi/utilities/colori-custom/colori-complementari-e-triadici.html
@@ -121,7 +121,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/colori-primari.html
+++ b/static/examples/bsi/utilities/colori-custom/colori-primari.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/colori-secondari.html
+++ b/static/examples/bsi/utilities/colori-custom/colori-secondari.html
@@ -120,7 +120,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/grigi-chiari.html
+++ b/static/examples/bsi/utilities/colori-custom/grigi-chiari.html
@@ -136,7 +136,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/varianti-colori-neutrali.html
+++ b/static/examples/bsi/utilities/colori-custom/varianti-colori-neutrali.html
@@ -150,7 +150,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/varianti-colori-secondari-analoghi.html
+++ b/static/examples/bsi/utilities/colori-custom/varianti-colori-secondari-analoghi.html
@@ -168,7 +168,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/varianti-colori-secondari-complementari-e-triadici.html
+++ b/static/examples/bsi/utilities/colori-custom/varianti-colori-secondari-complementari-e-triadici.html
@@ -192,7 +192,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori-custom/varianti-monocromatiche-del-colore-base.html
+++ b/static/examples/bsi/utilities/colori-custom/varianti-monocromatiche-del-colore-base.html
@@ -162,7 +162,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori/sfondo.html
+++ b/static/examples/bsi/utilities/colori/sfondo.html
@@ -131,7 +131,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/colori/testo.html
+++ b/static/examples/bsi/utilities/colori/testo.html
@@ -128,7 +128,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/icone/allineamenti.html
+++ b/static/examples/bsi/utilities/icone/allineamenti.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/icone/base.html
+++ b/static/examples/bsi/utilities/icone/base.html
@@ -119,7 +119,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/icone/icone-disponibili.html
+++ b/static/examples/bsi/utilities/icone/icone-disponibili.html
@@ -631,7 +631,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/icone/varianti-colori.html
+++ b/static/examples/bsi/utilities/icone/varianti-colori.html
@@ -125,7 +125,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/icone/varianti-dimensioni-con-padding.html
+++ b/static/examples/bsi/utilities/icone/varianti-dimensioni-con-padding.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/bsi/utilities/icone/varianti-dimensioni.html
+++ b/static/examples/bsi/utilities/icone/varianti-dimensioni.html
@@ -123,7 +123,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@2.7.5/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/static/examples/templates/base.html
+++ b/static/examples/templates/base.html
@@ -117,7 +117,7 @@
     <script
         src="https://cdn.jsdelivr.net/npm/bootstrap-italia@{{bsiversion}}/dist/js/bootstrap-italia.bundle.min.js"></script>
     <script>
-        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/dist/fonts/");
+        bootstrap.loadFonts(window.__PUBLIC_PATH__ = "/fonts/");
 
         // tooltip
         var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))


### PR DESCRIPTION
Reduce the noise caused at build by too much output, so we don't risk to miss important messages.

Building DEBUG=true re-enables the logs.

Also just use cp(1) and ln(1) instead of a node package.