### PR TITLE
content: switch info to help icon for hero/pretext

### DIFF
--- a/src/data/content/community.yaml
+++ b/src/data/content/community.yaml
@@ -31,7 +31,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/community/notizie/20221020-benvenuto-kit-privacy.yaml
+++ b/src/data/content/community/notizie/20221020-benvenuto-kit-privacy.yaml
@@ -39,7 +39,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/community/piano-attivita.yaml
+++ b/src/data/content/community/piano-attivita.yaml
@@ -87,7 +87,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/community/piano-attivita/archivio-storico.yaml
+++ b/src/data/content/community/piano-attivita/archivio-storico.yaml
@@ -104,7 +104,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/design-system.yaml
+++ b/src/data/content/design-system.yaml
@@ -51,7 +51,7 @@ components:
     subtitle: "L’insieme di indicazioni e risorse per realizzare siti e servizi pubblici di qualità, efficienti e accessibili" #C
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/design-system/come-contribuire.yaml
+++ b/src/data/content/design-system/come-contribuire.yaml
@@ -62,7 +62,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/come-contribuire/modello-di-contribuzione.yaml
+++ b/src/data/content/design-system/come-contribuire/modello-di-contribuzione.yaml
@@ -61,7 +61,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: "Prendi parte all’evoluzione del design system dedicato alla PA italiana: contribuisci alle discussioni, agli avanzamenti tecnici e di design e scopri come proporre novità e nuove idee da condividere con il team e la community di Designers Italia."

--- a/src/data/content/design-system/come-contribuire/per-il-design.yaml
+++ b/src/data/content/design-system/come-contribuire/per-il-design.yaml
@@ -61,7 +61,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/come-contribuire/per-la-documentazione.yaml
+++ b/src/data/content/design-system/come-contribuire/per-la-documentazione.yaml
@@ -61,7 +61,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/come-contribuire/per-lo-sviluppo.yaml
+++ b/src/data/content/design-system/come-contribuire/per-lo-sviluppo.yaml
@@ -61,7 +61,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/come-iniziare.yaml
+++ b/src/data/content/design-system/come-iniziare.yaml
@@ -39,7 +39,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/come-iniziare/per-designer.yaml
+++ b/src/data/content/design-system/come-iniziare/per-designer.yaml
@@ -39,7 +39,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/come-iniziare/per-responsabili-progetto.yaml
+++ b/src/data/content/design-system/come-iniziare/per-responsabili-progetto.yaml
@@ -39,7 +39,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/come-iniziare/per-sviluppatori.yaml
+++ b/src/data/content/design-system/come-iniziare/per-sviluppatori.yaml
@@ -39,7 +39,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/componenti.yaml
+++ b/src/data/content/design-system/componenti.yaml
@@ -42,7 +42,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/design-system/fondamenti.yaml
+++ b/src/data/content/design-system/fondamenti.yaml
@@ -39,7 +39,7 @@ components:
       addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: |

--- a/src/data/content/modelli.yaml
+++ b/src/data/content/modelli.yaml
@@ -46,7 +46,7 @@ components:
     subtitle: Le risorse per realizzare il sito e i servizi digitali della tua amministrazione #C
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/modelli/comuni.yaml
+++ b/src/data/content/modelli/comuni.yaml
@@ -97,7 +97,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/modelli/comuni/adotta-il-modello-di-servizi-digitali-comunali.yaml
+++ b/src/data/content/modelli/comuni/adotta-il-modello-di-servizi-digitali-comunali.yaml
@@ -93,7 +93,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/modelli/comuni/adotta-il-modello-di-sito-comunale.yaml
+++ b/src/data/content/modelli/comuni/adotta-il-modello-di-sito-comunale.yaml
@@ -94,7 +94,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/modelli/scuole.yaml
+++ b/src/data/content/modelli/scuole.yaml
@@ -96,7 +96,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/modelli/scuole/adotta-il-modello-di-sito-scolastico.yaml
+++ b/src/data/content/modelli/scuole/adotta-il-modello-di-sito-scolastico.yaml
@@ -93,7 +93,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/norme-e-riferimenti.yaml
+++ b/src/data/content/norme-e-riferimenti.yaml
@@ -55,7 +55,7 @@ components:
     subtitle: La documentazione ufficiale che ti guida nella progettazione per la Pubblica Amministrazione, mettendo le persone al centro #C
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/norme-e-riferimenti/linee-guida-accessibilita.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-accessibilita.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design.yaml
@@ -81,7 +81,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/norme-e-riferimenti/manuale-operativo-di-design.yaml
+++ b/src/data/content/norme-e-riferimenti/manuale-operativo-di-design.yaml
@@ -83,7 +83,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/progetto.yaml
+++ b/src/data/content/progetto.yaml
@@ -46,7 +46,7 @@ components:
     subtitle: Siamo il punto di riferimento per la progettazione dei servizi digitali della Pubblica Amministrazione #C
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/progetto/formazione-e-disseminazione.yaml
+++ b/src/data/content/progetto/formazione-e-disseminazione.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/progetto/storia.yaml
+++ b/src/data/content/progetto/storia.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/progetto/visione-e-missione.yaml
+++ b/src/data/content/progetto/visione-e-missione.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare.yaml
+++ b/src/data/content/risorse-per-progettare.yaml
@@ -48,7 +48,7 @@ components:
     subtitle: Strumenti e attività già pronti per creare siti, app e interfacce digitali dei servizi pubblici #C
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/comprendere.yaml
+++ b/src/data/content/risorse-per-progettare/comprendere.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/comprendere/analisi-del-contesto.yaml
+++ b/src/data/content/risorse-per-progettare/comprendere/analisi-del-contesto.yaml
@@ -100,7 +100,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/comprendere/esperienza-utente.yaml
+++ b/src/data/content/risorse-per-progettare/comprendere/esperienza-utente.yaml
@@ -98,7 +98,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/comprendere/interviste-soggetti-coinvolti.yaml
+++ b/src/data/content/risorse-per-progettare/comprendere/interviste-soggetti-coinvolti.yaml
@@ -100,7 +100,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/comprendere/questionario-online.yaml
+++ b/src/data/content/risorse-per-progettare/comprendere/questionario-online.yaml
@@ -98,7 +98,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/organizzare.yaml
+++ b/src/data/content/risorse-per-progettare/organizzare.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/organizzare/privacy.yaml
+++ b/src/data/content/risorse-per-progettare/organizzare/privacy.yaml
@@ -94,7 +94,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/progettare.yaml
+++ b/src/data/content/risorse-per-progettare/progettare.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/progettare/architettura-dell-informazione.yaml
+++ b/src/data/content/risorse-per-progettare/progettare/architettura-dell-informazione.yaml
@@ -100,7 +100,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/progettare/co-progettazione.yaml
+++ b/src/data/content/risorse-per-progettare/progettare/co-progettazione.yaml
@@ -99,7 +99,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/progettare/contenuti-e-linguaggio.yaml
+++ b/src/data/content/risorse-per-progettare/progettare/contenuti-e-linguaggio.yaml
@@ -99,7 +99,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/progettare/prototipazione.yaml
+++ b/src/data/content/risorse-per-progettare/progettare/prototipazione.yaml
@@ -97,7 +97,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/progettare/seo.yaml
+++ b/src/data/content/risorse-per-progettare/progettare/seo.yaml
@@ -98,7 +98,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/realizzare.yaml
+++ b/src/data/content/risorse-per-progettare/realizzare.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/realizzare/costruzione-interfaccia.yaml
+++ b/src/data/content/risorse-per-progettare/realizzare/costruzione-interfaccia.yaml
@@ -100,7 +100,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/realizzare/sviluppo-interfaccia.yaml
+++ b/src/data/content/risorse-per-progettare/realizzare/sviluppo-interfaccia.yaml
@@ -99,7 +99,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/validare.yaml
+++ b/src/data/content/risorse-per-progettare/validare.yaml
@@ -80,7 +80,7 @@ components:
         addonClasses: mt-3 text-uppercase
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/validare/test-di-usabilita.yaml
+++ b/src/data/content/risorse-per-progettare/validare/test-di-usabilita.yaml
@@ -97,7 +97,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C

--- a/src/data/content/risorse-per-progettare/validare/web-analytics.yaml
+++ b/src/data/content/risorse-per-progettare/validare/web-analytics.yaml
@@ -99,7 +99,7 @@ components:
     imgRatio: 4x3
     pretext:
       icon:
-        icon: sprites.svg#it-info-circle
+        icon: sprites.svg#it-help-circle
         size: sm
       text: In breve
     text: | #C


### PR DESCRIPTION
I would like to replace the information icon with an help icon, I mean the icon of each 'IN BREVE' pretext. 
We need to do this to distinguish the icon from the interactive kangaroo information icons with tooltips, a problem identified by @bfabio a few weeks ago.  

Currently: 
![Currently](https://github.com/italia/designers.italia.it/assets/6736103/1f84738a-a70f-4439-b369-6ba1a266cea4)

Proposal:
![Proposal](https://github.com/italia/designers.italia.it/assets/6736103/ae7be63a-2a24-4e76-8645-4eefd57eb546)
