### PR TITLE
fix: back-to-top button in /design-system pages

### DIFF
--- a/src/templates/design-system-component.js
+++ b/src/templates/design-system-component.js
@@ -2,6 +2,7 @@ import * as React from "react";
 import "../scss/styles.scss";
 import "../js/globals";
 
+import BackToTopEl from "../components/back-to-top/back-to-top";
 import Skiplinks from "../components/skiplinks/skiplinks";
 import Header from "../components/header/header";
 import Footer from "../components/footer/footer";
@@ -80,6 +81,14 @@ function Template({ Pagedata, pageContext, location, lastModified }) {
         <Feedback />
       </div>
       <Footer {...FooterData.footer} />
+      <BackToTopEl
+        positionTop={0}
+        scrollLimit={100}
+        duration={800}
+        easing="easeInOutSine"
+        ariaLabel={FooterData.footer.backToTop.ariaLabel}
+        className="back-to-top mb-5 mb-lg-0"
+      />
     </div>
   );
 }

--- a/src/templates/design-system-index-components-tags.js
+++ b/src/templates/design-system-index-components-tags.js
@@ -169,6 +169,7 @@ function TagsDesignSystem({ children, pageContext, location, data }) {
           duration={800}
           easing="easeInOutSine"
           ariaLabel={FooterData.footer.backToTop.ariaLabel}
+          className="back-to-top mb-5 mb-lg-0"
         />
       </div>
     </div>


### PR DESCRIPTION
* Add the missing back-to-top button to the single component pages
* Add the proper button margin in the tags template