### PR TITLE
fix(sandbox): move video poster to useEffect - don't merge

### DIFF
--- a/src/components/media-player/media-player.js
+++ b/src/components/media-player/media-player.js
@@ -37,8 +37,11 @@ function MediaPlayerEl({ url, lang, subtitles, trascription, poster }) {
     new AcceptOverlay(document.getElementById(`${videoId}-accept-video`), {
       service: "youtube.com",
     });
+    const videoOptions = {
+      poster: `${poster}`,
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    video = new VideoPlayer(document.getElementById(videoId));
+    video = new VideoPlayer(document.getElementById(videoId), videoOptions);
     const ButtonComp = videojs.getComponent("Button");
     const privacyPolicyButton = new ButtonComp(video.player, {
       clickHandler() {
@@ -80,7 +83,6 @@ function MediaPlayerEl({ url, lang, subtitles, trascription, poster }) {
               <button
                 onClick={() => {
                   video.setYouTubeVideo(url);
-                  video.addTrack(subtitles);
                 }}
                 type="button"
                 id={`${videoId}-accept-video`}
@@ -106,7 +108,6 @@ function MediaPlayerEl({ url, lang, subtitles, trascription, poster }) {
           <video
             controls
             data-bs-video
-            poster={poster}
             id={videoId}
             className="video-js"
             width="640"


### PR DESCRIPTION
@astagi with @cfabry we noticed a problem/weird behaviour with the poster image (placehoder). 
So I tried this solution to move the poster options into the js part `useEffect` of the media player component and not directly into the `video` tag. I think our videojs plugin needs to better manage the timing and loading of the poster and its interaction with the underlying youtube video. Let's do some testing. 