### PR TITLE
fix: chips margins

### DIFF
--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -3,9 +3,9 @@
 
 .chip {
 	text-decoration: none;
-	padding-left: var(--chip-x-padding);
-	padding-right: var(--chip-x-padding);
+	margin: 4px 8px 8px 0px; // fix to move to BSI
 	&.chip-simple {
+		padding-left: var(--chip-x-padding);
 		padding-right: var(--chip-x-padding);
 	}
 	.chip-label {

--- a/src/scss/vars.scss
+++ b/src/scss/vars.scss
@@ -69,7 +69,7 @@
 	//-chips
 	--chip-font-size: 0.875rem;
 	--chip-secondary-border-color: rgba(212, 212, 212, 1);
-	--chip-x-padding: 24px;
+	--chip-x-padding: 16px;
 	//-simple-cta
 	--simple-cta-color: var(--color-primary);
   	--simple-cta-color-hover: #0052a3;


### PR DESCRIPTION
fix: #1098 

<img src="https://github.com/italia/designers.italia.it/assets/6736103/9d39fd3e-4fac-448c-947e-66476b0c4110" width="50%"/><img src="https://github.com/italia/designers.italia.it/assets/6736103/9bbe29f0-1468-4996-b638-1052cb616f88" width="50%"/>

<img src="https://github.com/italia/designers.italia.it/assets/6736103/f4f2e887-da67-441a-b8b2-9b391affa2a3" width="50%"/><img src="https://github.com/italia/designers.italia.it/assets/6736103/114c6284-2634-43db-911b-4bdd1635d46a" width="50%"/>

To simplify as soon as this fix https://github.com/italia/bootstrap-italia/pull/1020 will be merged in BSI. 