### PR TITLE
fix: community links SEO min spacing

### DIFF
--- a/src/components/footer-main/footer-main.scss
+++ b/src/components/footer-main/footer-main.scss
@@ -1,4 +1,14 @@
 .it-footer {
+  .link-list-wrapper ul li {
+      padding-top: 4px;
+      padding-bottom: 4px;
+    &:first-child {
+      padding-top: 0;
+    }
+    &:last-child {
+      padding-bottom: 0;
+    }  
+  }
   .link-list-wrapper ul li a span,
   .link-list-wrapper ul li a:hover span {
     color: #FFF;


### PR DESCRIPTION
See #851. 

This mini fix resolve the Lighthouse minimum touch size errors in the footer (community links) @bfabio 🎉 
![immagine](https://github.com/italia/designers.italia.it/assets/6736103/1e5620ad-73ac-4a85-bcdc-d276735fc3eb)

The error in the chips was already fixed last week with the corrections to the Bootstrap Italia component spacing. 

ps. this is a more "precise" approach than https://github.com/italia/designers.italia.it/pull/917, which remains just an interesting POC, I think we can close that, no? 

pps. maybe we can check this list spacing in the original Bootstrap Italia footer component. And if needed open a new PR with this fix there. 