### PR TITLE
chore(ci): update Lighthouse report message

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -56,7 +56,7 @@ jobs:
             const other_pages = manifest.filter(result => new URL(result.url).pathname !== '/')
 
             const comment = [
-                `### :zap: Lighthouse report for the home page :house:`,
+                `### ⚡ Lighthouse report for the home page 🏠`,
                 '| Category | Score |',
                 '| --- | --: |',
                 `| ${score(home_page.summary.performance)} Performance | ${home_page.summary.performance} |`,


### PR DESCRIPTION
Update the Lighthouse report message so to display the emotes.

Looks like GitHub doesn't expand shortcodes to emotes in headers anymore.