### PR TITLE
fix: footer logos images alt text

### DIFF
--- a/src/components/footer-brand/footer-brand.js
+++ b/src/components/footer-brand/footer-brand.js
@@ -32,11 +32,10 @@ function FooterBrand({ background, title, justifyLogos, logos }) {
                     target={value.blank ? "_blank" : undefined}
                     rel={value.blank ? "noreferrer" : undefined}
                     className="d-block"
-                    aria-label={value.ariaLabel}
                   >
                     <ImageResponsive
                       src={value.img}
-                      alt=""
+                      alt={value.ariaLabel}
                       className={value.small ? "small" : undefined}
                     />
                   </Link>


### PR DESCRIPTION
@astagi I solved a11y minor problem about footer logos. We don't need `aria-label`, but to use the right alternative texts (describing the function and not just the image) for those logo images...