### PR TITLE
fix(a11y): ctas and buttons external links + arialabels

### DIFF
--- a/src/data/content/community.yaml
+++ b/src/data/content/community.yaml
@@ -331,7 +331,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su Medium
-          screenReaderText: "l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -355,7 +355,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su Medium
-          screenReaderText: "l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -379,7 +379,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su Medium
-          screenReaderText: "l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -403,7 +403,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su Medium
-          screenReaderText: "l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -427,7 +427,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su Medium
-          screenReaderText: "l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -451,7 +451,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su Medium
-          screenReaderText: "l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs

--- a/src/data/content/community.yaml
+++ b/src/data/content/community.yaml
@@ -307,6 +307,7 @@ components:
         label: Vai al Medium di Designers Italia
         url: https://medium.com/designers-italia
         blank: true
+        ariaLabel: Vai al Medium di Designers Italia (si apre in una nuova finestra)
         icon:
           icon: sprites.svg#it-medium
           color: primary

--- a/src/data/content/community/piano-attivita.yaml
+++ b/src/data/content/community/piano-attivita.yaml
@@ -155,7 +155,7 @@ components:
           ctas:
           - label: Vai alla notizia #C
             url: "/community/notizie/20231107-esperienza-del-cittadino-nei-servizi-pubblici-dalla-misura-alla-pratica/" #M
-            blank: true #M #C true if new tab for external links
+            blank: false #M #C true if new tab for external links
             icon:
               icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -230,6 +230,7 @@ components:
           - label: Vai alla board di progetto per seguire i lavori #C
             url: https://github.com/orgs/italia/projects/15 #M
             blank: true #M #C true if new tab for external links
+            screenReaderText: " (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-github #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -629,6 +630,7 @@ components:
           - label: 'Leggi "Una grammatica dei servizi pubblici digitali"' #C
             url: https://medium.com/designers-italia/una-grammatica-dei-servizi-pubblici-digitali-7077aa1fc5ef #M
             blank: true #M #C true if new tab for external links
+            screenReaderText: " (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-medium #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/design-system/come-contribuire.yaml
+++ b/src/data/content/design-system/come-contribuire.yaml
@@ -145,7 +145,7 @@ components:
     #       ctas:
     #       - label: "Scopri come iniziare se sei un designer" #C
     #         url: "/design-system/come-iniziare/per-designer/" #M
-    #         blank: true #M #C true if new tab for external links
+    #         blank: false #M #C true if new tab for external links
     #         icon:
     #           icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
     #           color: primary
@@ -155,7 +155,7 @@ components:
     #           addonClasses: ms-2
     #       - label: "Scopri come iniziare se sei uno sviluppatore" #C
     #         url: "/design-system/come-iniziare/per-sviluppatori/"
-    #         blank: true #M #C true if new tab for external links
+    #         blank: false #M #C true if new tab for external links
     #         icon:
     #           icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
     #           color: primary

--- a/src/data/content/design-system/come-contribuire/modello-di-contribuzione.yaml
+++ b/src/data/content/design-system/come-contribuire/modello-di-contribuzione.yaml
@@ -124,7 +124,7 @@ components:
             - label: "Conosci il fondamento Princìpi e intenzioni?" #C
               # screenReaderText: ""
               url: "/design-system/fondamenti/principi-e-intenzioni/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -172,7 +172,7 @@ components:
             - label: "Vai al piano attività" #C
               # screenReaderText: ""
               url: "/community/piano-attivita/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -181,7 +181,7 @@ components:
                 size: sm
                 addonClasses: ms-2
             - label: "Attività in lavorazione" #C
-              screenReaderText: " su GitHub"
+              screenReaderText: " (GitHub, si apre in una nuova finestra)"
               url: https://github.com/orgs/italia/projects/17/views/5 #M
               blank: true #M #C true if new tab for external links
               icon:

--- a/src/data/content/design-system/come-contribuire/per-il-design.yaml
+++ b/src/data/content/design-system/come-contribuire/per-il-design.yaml
@@ -129,7 +129,7 @@ components:
             - label: "Conosci il modello di contribuzione?" #C
               screenReaderText: ""
               url: "/design-system/come-contribuire/modello-di-contribuzione/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -151,9 +151,9 @@ components:
             Controlla se già esiste una discussione sul tema che ti interessa, o su un tema simile. Se esiste, vai nella segnalazione dedicata e partecipa lasciando un commento. Se ti interessa lavorare a un contributo di design sul tema scopri di seguito la procedura per inviare contributi e proponili nella discussione.  
           ctas: 
             - label: "Discussioni su UI Kit Italia" #C
-              screenReaderText: ""
               url: https://github.com/italia/design-ui-kit/issues #M
               blank: true #M #C true if new tab for external links
+              screenReaderText: " (si apre in una nuova finestra)"
               icon:
                 icon: sprites.svg#it-github #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -162,7 +162,7 @@ components:
                 size: sm
                 addonClasses: ms-2
             - label: "Discussioni su Design Tokens Italia" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-tokens-italia/issues #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -181,7 +181,7 @@ components:
             Se il tema di tuo interesse non è nella lista puoi proporre una nuova segnalazione. Ricorda di inserire tutti i dettagli che ritieni necessari per approfondire il tema, in modo da consentire alla community e al team di Designers Italia di avere un quadro chiaro e il più possibile completo della tua proposta.    
           ctas: 
             - label: "Nuova segnalazione UI Kit Italia" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-ui-kit/issues/new?assignees=&labels=design%20system&projects=&template=apri-una-segnalazione.it.yaml #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -192,7 +192,7 @@ components:
                 size: sm
                 addonClasses: ms-2
             - label: "Nuova segnalazione Design Tokens Italia" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-tokens-italia/issues/new?assignees=&labels=design%20system&projects=&template=apri-una-segnalazione.it.yaml #M
               blank: true #M #C true if new tab for external links
               icon:

--- a/src/data/content/design-system/come-contribuire/per-la-documentazione.yaml
+++ b/src/data/content/design-system/come-contribuire/per-la-documentazione.yaml
@@ -127,7 +127,7 @@ components:
             - label: "Conosci il modello di contribuzione?" #C
               screenReaderText: ""
               url: "/design-system/come-contribuire/modello-di-contribuzione/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -162,7 +162,7 @@ components:
               Controlla in via preliminare se già esiste una discussione sul tema che ti interessa, o su un tema simile. Se già esiste, vai alla segnalazione dedicata e partecipa lasciando un commento. Se ti interessa lavorare a un contributo sul tema proponiti lasciando un commento nella discussione, evidenziando intenzioni e possibilità.
           ctas: 
             - label: "Discussioni sulla documentazione" #C
-              # screenReaderText: " relative alla documentazione"
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/designers.italia.it/issues?q=is%3Aissue+is%3Aopen+label%3A%22design+system%22 #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -181,7 +181,7 @@ components:
             Se il tema di tuo interesse non è presente nella lista puoi proporre una nuova segnalazione. Ricorda di inserire nella nuova segnalazione tutti i dettagli che ritieni necessari per approfondire il tema, in modo da consentire alla community e al team di Designers Italia di avere un quadro chiaro e il più possibile completo della tua proposta.   
           ctas:
             - label: "Nuova segnalazione" #C
-              screenReaderText: " relativa alla documentazione"
+              screenReaderText: " relativa alla documentazione (si apre in una nuova finestra)"
               url: https://github.com/italia/designers.italia.it/issues/new?assignees=&labels=design%20system&projects=&template=apri-una-segnalazione.it.yaml #M
               blank: true #M #C true if new tab for external links
               icon:

--- a/src/data/content/design-system/come-contribuire/per-lo-sviluppo.yaml
+++ b/src/data/content/design-system/come-contribuire/per-lo-sviluppo.yaml
@@ -117,9 +117,8 @@ components:
             Premessa importante: assicurati di conoscere i [fondamenti del design system del Paese](/design-system/fondamenti/) e [le risorse per sviluppatori](/design-system/come-iniziare/per-sviluppatori/). 
           ctas: 
             - label: "Conosci il modello di contribuzione?" #C
-              screenReaderText: ""
               url: "/design-system/come-contribuire/modello-di-contribuzione/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -136,7 +135,7 @@ components:
             Controlla se esiste già una discussione sul tema che ti interessa, o su un tema simile. Se esiste, vai alla segnalazione dedicata e partecipa lasciando un commento. Se ti interessa lavorare a un contributo di sviluppo sul tema scopri di seguito come inviare contributi e proponilo nella discussione.  
           ctas: 
             - label: "Discussioni su Bootstrap Italia" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/bootstrap-italia/issues #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -147,7 +146,7 @@ components:
                 size: sm
                 addonClasses: ms-2
             - label: "Discussioni su Design Tokens Italia" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-tokens-italia/issues #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -166,7 +165,7 @@ components:
             Se il tema di tuo interesse non è nella lista, puoi proporre una nuova segnalazione. Ricorda di inserire tutti i dettagli che ritieni necessari per approfondire il tuo contributo. 
           ctas: 
             - label: "Nuova segnalazione Bootstrap Italia" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/bootstrap-italia/issues/new #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -177,7 +176,7 @@ components:
                 size: sm
                 addonClasses: ms-2
             - label: "Nuova segnalazione Design Tokens Italia" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-tokens-italia/issues/new #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -211,9 +210,8 @@ components:
             Nelle lavorazioni poni attenzione al rispetto dei fondamenti del design system del Paese. Può esserti utile il "workflow per migliorare lo sviluppo dei componenti" del [fondamento accessibilità](/design-system/fondamenti/accessibilita/). 
           ctas: 
             - label: "Approfondisci il Fondamento accessibilità" #C
-              screenReaderText: ""
               url: "/design-system/fondamenti/accessibilita/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -236,9 +234,8 @@ components:
             4. indica la pull request nella segnalazione aperta al punto 1 o in un commento dedicato
           ctas: 
             - label: "Approfondisci il Fondamento Design Tokens" #C
-              screenReaderText: ""
               url: "/design-system/fondamenti/design-tokens/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -276,7 +273,7 @@ components:
             Puoi seguire i lavori in corso per l'aggiornamento a Bootstrap Italia v2 sul [repository](https://github.com/italia/design-react-kit/).
           ctas: 
             - label: "Discussioni su React Kit" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-react-kit/issues #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -287,7 +284,7 @@ components:
                 size: sm
                 addonClasses: ms-2
             - label: "Nuova segnalazione React Kit" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-react-kit/issues/new #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -306,7 +303,7 @@ components:
             Puoi seguire i lavori in corso per l'aggiornamento a Bootstrap Italia v2 sul [repository](https://github.com/italia/design-angular-kit/).
           ctas: 
             - label: "Discussioni su Angular Kit" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-angular-kit/issues #M
               blank: true #M #C true if new tab for external links
               icon:
@@ -317,7 +314,7 @@ components:
                 size: sm
                 addonClasses: ms-2
             - label: "Nuova segnalazione Angular Kit" #C
-              screenReaderText: ""
+              screenReaderText: " (si apre in una nuova finestra)"
               url: https://github.com/italia/design-angular-kit/issues/new #M
               blank: true #M #C true if new tab for external links
               icon:

--- a/src/data/content/design-system/come-iniziare.yaml
+++ b/src/data/content/design-system/come-iniziare.yaml
@@ -132,7 +132,7 @@ components:
     #       ctas:
     #       - label: "Scopri come iniziare se sei un designer" #C
     #         url: "/design-system/come-iniziare/per-designer/" #M
-    #         blank: true #M #C true if new tab for external links
+    #         blank: false #M #C true if new tab for external links
     #         icon:
     #           icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
     #           color: primary
@@ -142,7 +142,7 @@ components:
     #           addonClasses: ms-2
     #       - label: "Scopri come iniziare se sei uno sviluppatore" #C
     #         url: "/design-system/come-iniziare/per-sviluppatori/"
-    #         blank: true #M #C true if new tab for external links
+    #         blank: false #M #C true if new tab for external links
     #         icon:
     #           icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
     #           color: primary

--- a/src/data/content/design-system/come-iniziare/per-responsabili-progetto.yaml
+++ b/src/data/content/design-system/come-iniziare/per-responsabili-progetto.yaml
@@ -199,6 +199,7 @@ components:
           - label: Scopri le ultime discussioni e partecipa su Forum Italia #C
             url: https://forum.italia.it/c/design/user-interface/22 #M
             blank: true
+            screenReaderText: " (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/design-system/componenti.yaml
+++ b/src/data/content/design-system/componenti.yaml
@@ -312,6 +312,7 @@ components:
     #       - label: "Vai allo UI Kit nella community Figma " #C
     #         url: https://www.figma.com/community/file/1105848677422572920 #M
     #         blank: true #M #C true if new tab for external links
+    #          screenReaderText: " (si apre in una nuova finestra)"
     #         icon:
     #           icon: sprites.svg#it-figma #C #I #it-arrow-right | it-external-link for external links
     #           color: primary
@@ -322,6 +323,7 @@ components:
     #       - label: "Vai a Bootstrap Italia su GitHub " #C
     #         url: https://github.com/italia/bootstrap-italia #M
     #         blank: true #M #C true if new tab for external links
+    #          screenReaderText: " (si apre in una nuova finestra)"
     #         icon:
     #           icon: sprites.svg#it-github #C #I #it-arrow-right | it-external-link for external links
     #           color: primary

--- a/src/data/content/design-system/componenti/accordion.yaml
+++ b/src/data/content/design-system/componenti/accordion.yaml
@@ -343,7 +343,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -536,7 +536,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/affix.yaml
+++ b/src/data/content/design-system/componenti/affix.yaml
@@ -165,7 +165,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -198,7 +198,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/alert.yaml
+++ b/src/data/content/design-system/componenti/alert.yaml
@@ -260,7 +260,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -292,7 +292,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/autocomplete.yaml
+++ b/src/data/content/design-system/componenti/autocomplete.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/avatar.yaml
+++ b/src/data/content/design-system/componenti/avatar.yaml
@@ -207,7 +207,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -239,7 +239,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/back-to-top.yaml
+++ b/src/data/content/design-system/componenti/back-to-top.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/back.yaml
+++ b/src/data/content/design-system/componenti/back.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/badge.yaml
+++ b/src/data/content/design-system/componenti/badge.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/bottomnav.yaml
+++ b/src/data/content/design-system/componenti/bottomnav.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/breadcrumbs.yaml
+++ b/src/data/content/design-system/componenti/breadcrumbs.yaml
@@ -327,7 +327,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -359,7 +359,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/buttons.yaml
+++ b/src/data/content/design-system/componenti/buttons.yaml
@@ -323,7 +323,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -355,7 +355,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/callout.yaml
+++ b/src/data/content/design-system/componenti/callout.yaml
@@ -155,7 +155,7 @@ tabs:
                     label: Scheda storybook
                     url: https://italia.github.io/design-react-kit/?path=/story/documentazione-componenti-callout--page
                     blank: true
-                    screenReaderText: "(si apre in una nuova finestra)"
+                    screenReaderText: " (si apre in una nuova finestra)"
                     icon:
                       icon: sprites.svg#it-external-link
                       size: sm
@@ -269,7 +269,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -301,7 +301,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/card.yaml
+++ b/src/data/content/design-system/componenti/card.yaml
@@ -262,7 +262,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -294,7 +294,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/carousel.yaml
+++ b/src/data/content/design-system/componenti/carousel.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/chips.yaml
+++ b/src/data/content/design-system/componenti/chips.yaml
@@ -199,7 +199,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -231,7 +231,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/collapse.yaml
+++ b/src/data/content/design-system/componenti/collapse.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/datepicker.yaml
+++ b/src/data/content/design-system/componenti/datepicker.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/dimmer.yaml
+++ b/src/data/content/design-system/componenti/dimmer.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/dropdown.yaml
+++ b/src/data/content/design-system/componenti/dropdown.yaml
@@ -316,7 +316,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -348,7 +348,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/footer.yaml
+++ b/src/data/content/design-system/componenti/footer.yaml
@@ -192,7 +192,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -224,7 +224,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/form.yaml
+++ b/src/data/content/design-system/componenti/form.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/forward.yaml
+++ b/src/data/content/design-system/componenti/forward.yaml
@@ -156,7 +156,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -189,7 +189,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/header.yaml
+++ b/src/data/content/design-system/componenti/header.yaml
@@ -264,7 +264,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -297,7 +297,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/hero.yaml
+++ b/src/data/content/design-system/componenti/hero.yaml
@@ -190,7 +190,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -222,7 +222,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/input.yaml
+++ b/src/data/content/design-system/componenti/input.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/list.yaml
+++ b/src/data/content/design-system/componenti/list.yaml
@@ -213,7 +213,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -245,7 +245,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/megamenu.yaml
+++ b/src/data/content/design-system/componenti/megamenu.yaml
@@ -196,7 +196,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -229,7 +229,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/modal.yaml
+++ b/src/data/content/design-system/componenti/modal.yaml
@@ -264,7 +264,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -296,7 +296,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/navscroll.yaml
+++ b/src/data/content/design-system/componenti/navscroll.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/notifications.yaml
+++ b/src/data/content/design-system/componenti/notifications.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/number-input.yaml
+++ b/src/data/content/design-system/componenti/number-input.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/overlay.yaml
+++ b/src/data/content/design-system/componenti/overlay.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/pagination.yaml
+++ b/src/data/content/design-system/componenti/pagination.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/popover.yaml
+++ b/src/data/content/design-system/componenti/popover.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/progress-indicators.yaml
+++ b/src/data/content/design-system/componenti/progress-indicators.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/radio-button.yaml
+++ b/src/data/content/design-system/componenti/radio-button.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/rating.yaml
+++ b/src/data/content/design-system/componenti/rating.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/sections.yaml
+++ b/src/data/content/design-system/componenti/sections.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/select.yaml
+++ b/src/data/content/design-system/componenti/select.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/sidebar.yaml
+++ b/src/data/content/design-system/componenti/sidebar.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/skiplinks.yaml
+++ b/src/data/content/design-system/componenti/skiplinks.yaml
@@ -181,7 +181,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -214,7 +214,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/steppers.yaml
+++ b/src/data/content/design-system/componenti/steppers.yaml
@@ -156,7 +156,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -189,7 +189,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/sticky.yaml
+++ b/src/data/content/design-system/componenti/sticky.yaml
@@ -156,7 +156,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -189,7 +189,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/tabs.yaml
+++ b/src/data/content/design-system/componenti/tabs.yaml
@@ -168,7 +168,7 @@ tabs:
                     label: Scheda storybook
                     url: https://italia.github.io/design-react-kit/?path=/story/documentazione-componenti-bottoni--page
                     blank: true
-                    screenReaderText: "(si apre in una nuova finestra)"
+                    screenReaderText: " (si apre in una nuova finestra)"
                     icon:
                       icon: sprites.svg#it-external-link
                       size: sm
@@ -281,7 +281,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -314,7 +314,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/thumbnav.yaml
+++ b/src/data/content/design-system/componenti/thumbnav.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/timeline.yaml
+++ b/src/data/content/design-system/componenti/timeline.yaml
@@ -160,7 +160,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -193,7 +193,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/timepicker.yaml
+++ b/src/data/content/design-system/componenti/timepicker.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/toggles.yaml
+++ b/src/data/content/design-system/componenti/toggles.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/toolbar.yaml
+++ b/src/data/content/design-system/componenti/toolbar.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/tooltip.yaml
+++ b/src/data/content/design-system/componenti/tooltip.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/transfer.yaml
+++ b/src/data/content/design-system/componenti/transfer.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/upload.yaml
+++ b/src/data/content/design-system/componenti/upload.yaml
@@ -155,7 +155,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -187,7 +187,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/componenti/video-player.yaml
+++ b/src/data/content/design-system/componenti/video-player.yaml
@@ -223,7 +223,7 @@ tabs:
             - label: Vai alla scheda per designer #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-designer/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary
@@ -256,7 +256,7 @@ tabs:
             - label: Vai alla scheda per sviluppatori #C
               # screenReaderText: " (si apre in una nuova finestra)" #C
               url: "/design-system/come-iniziare/per-sviluppatori/" #M
-              blank: true #M #C true if new tab for external links
+              blank: false #M #C true if new tab for external links
               icon:
                 icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
                 color: primary

--- a/src/data/content/design-system/fondamenti/accessibilita.yaml
+++ b/src/data/content/design-system/fondamenti/accessibilita.yaml
@@ -250,7 +250,7 @@ components:
         #   ctas: 
         #   - label: "Vai al fondamento Linguaggio" #C
         #     url: "/design-system/fondamenti/linguaggio/" #M
-        #     blank: true #M #C true if new tab for external links
+        #     blank: false #M #C true if new tab for external links
         #     icon:
         #       icon: sprites.svg#it-arrow-right #C #I #it-arrow-right | it-external-link for external links
         #       color: primary

--- a/src/data/content/design-system/fondamenti/design-tokens.yaml
+++ b/src/data/content/design-system/fondamenti/design-tokens.yaml
@@ -228,6 +228,7 @@ components:
           ctas:
           - label: "Vai a UI Kit Italia" #C
             url: https://www.figma.com/file/2gaQw683ZazAPEILQtFLZF/%5BDesign-system-%E2%80%A8del-Paese%5D?node-id=986%3A122&t=9FQglVyiZQuCL7nt-1 #M
+            screenReaderText: " (si apre in una nuova finestra)"
             blank: true #M #C true if new tab for external links
            
             icon:
@@ -249,6 +250,7 @@ components:
           ctas:
           - label: "Vai al repository Design Tokens Italia" #C
             url: https://github.com/italia/design-tokens-italia #M
+            screenReaderText: " (si apre in una nuova finestra)"
             blank: true #M #C true if new tab for external links
            
             icon:

--- a/src/data/content/design-system/fondamenti/versionamento.yaml
+++ b/src/data/content/design-system/fondamenti/versionamento.yaml
@@ -132,7 +132,7 @@ components:
           - label: Scopri la guida al versionamento semantico (semver) #C
             url: https://semver.org/lang/it/ #M
             blank: true #M #C true if new tab for external links
-           
+            screenReaderText: " (si apre in una nuova finestra)"          
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/index.yaml
+++ b/src/data/content/index.yaml
@@ -275,7 +275,7 @@ components:
       blank: true
       externalLink:
         label: Leggi su Medium
-        screenReaderText: "l'articolo completo"
+        screenReaderText: " (si apre in una nuova finestra)"
         icon:
           icon: sprites.svg#it-external-link
           size: xs
@@ -290,27 +290,6 @@ components:
     id: bannerBottom
     title: Diamo i numeri
     background: dark
-    # ctas:
-    # - icon:
-    #     icon: sprites.svg#it-external-link
-    #     color: white
-    #     align: middle
-    #     hidden: true
-    #     size: sm
-    #     addonClasses: ms-2
-    #   label: Dashboard
-    #   url: "#"
-    #   blank: true
-    # - icon:
-    #     icon: sprites.svg#it-external-link
-    #     color: white
-    #     align: middle
-    #     hidden: true
-    #     size: sm
-    #     addonClasses: ms-2
-    #   label: Open data
-    #   url: "#"
-    #   blank: true
     numbers:
       inline: true
       items:

--- a/src/data/content/index.yaml
+++ b/src/data/content/index.yaml
@@ -205,34 +205,9 @@ components:
       label: Esplora cosa accade nella community
       url: "community/"
       addonStyle: me-3 d-block
-    # - btnStyle: outline-primary
-    #   label: Vai al Medium di Designers Italia
-    #   icon:
-    #     icon: sprites.svg#it-external-link
-    #     color: primary
-    #     align: middle
-    #     size: sm
-    #     addonClasses: ms-2
+
     # CARDS
     cards:
-
-    #CARD with Button
-    # - title: "Community Lab sui temi dell’upgrade del Kit Design React"
-    #   headingLevel: 3
-    #   titleBig: false
-    #   titleSmall: false
-    #   customCol: col-lg-3
-    #   cardEvent: true
-    #   img: /images/600x400.png
-    #   alt: Descrizione immagine
-    #   imgRatio: 4x3
-    #   imgPlaceholder: false
-    #   dateOverlay:
-    #     day: 22
-    #     month: Aprile
-    #   url: "#"
-    #   tag:
-    #   label: Community Lab
 
     - title: 'Il 2023 di Designers Italia'
       headingLevel: 3

--- a/src/data/content/modelli/musei-civici.yaml
+++ b/src/data/content/modelli/musei-civici.yaml
@@ -288,11 +288,6 @@ components:
     headingLevel: 2
     background: null
     col4: false # FALSE notizie + Medium | TRUE eventi + media
-    # buttons:
-    #   - btnStyle: outline-primary
-    #     label: Esplora tutte le notizie sul modello #C
-    #     url: XXX #M
-    #     blank: false
 
     # CARDS
     cards:

--- a/src/data/content/norme-e-riferimenti.yaml
+++ b/src/data/content/norme-e-riferimenti.yaml
@@ -249,7 +249,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su Medium
-          screenReaderText: "l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -272,7 +272,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -290,7 +290,7 @@ components:
         url: https://medium.com/designers-italia/accessibili-usabili-e-inclusivi-per-una-progettazione-etica-dei-servizi-pubblici-digitali-186ed6ebc469
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs

--- a/src/data/content/norme-e-riferimenti.yaml
+++ b/src/data/content/norme-e-riferimenti.yaml
@@ -224,6 +224,7 @@ components:
         label: Vai al Medium di Designers Italia #C
         url: https://medium.com/designers-italia #M
         blank: true
+        ariaLabel: Vai al Medium di Designers Italia (si apre in una nuova finestra)
         icon:
           icon: sprites.svg#it-medium
           color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-1/azione-1.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-1/azione-1.yaml
@@ -244,7 +244,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -263,7 +263,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -290,7 +290,7 @@ components:
             Segui il principio di accessibilità by design, cioè fin dalle basi della progettazione, e il principio di accessibilità by default, cioè il principio secondo cui ogni tipo di documentazione e risorsa a supporto dovrebbe contenere i requisiti di accessibilità, per creare servizi digitali accessibili.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-            screenReaderText: "Accessibilità by design"
+            screenReaderText: "Accessibilità by design (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/introduzione-design-servizi-pubblici-digitali/accessibilita-by-design.html#accessibilita-by-design" #M
             blank: true #M #C true if new tab for external links
             icon:
@@ -310,7 +310,7 @@ components:
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
 
-            screenReaderText: "Accessibilità"
+            screenReaderText: "Accessibilità (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html#accessibilita" #M
             blank: true #M #C true if new tab for external links
             icon:

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-1.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-1.yaml
@@ -192,7 +192,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -210,7 +210,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -228,7 +228,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -269,8 +269,7 @@ components:
             Scegli l’approccio progettuale tra quelli proposti per affrontare al meglio il processo sotto diversi punti di vista: quello delle persone, delle procedure e della tecnologia.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
-            screenReaderText: "L'approccio progettuale"
+            screenReaderText: "L'approccio progettuale (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/introduzione-design-servizi-pubblici-digitali/approccio-progettuale.html#l-approccio-progettuale" #M
             blank: true #M #C true if new tab for external links
             icon:
@@ -288,8 +287,7 @@ components:
             Segui l’approccio strutturato in cinque fasi, utile come riferimento per impostare il progetto, capire quali figure/competenze coinvolgere e organizzare le attività da svolgere nell’ordine più adeguato.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
-            screenReaderText: "Il processo progettuale"
+            screenReaderText: "Il processo progettuale (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/introduzione-design-servizi-pubblici-digitali/processo-progettuale.html#il-processo-progettuale" #M
             blank: true #M #C true if new tab for external links
             icon:
@@ -307,10 +305,9 @@ components:
             Imposta una modalità di lavoro agile per orientare il processo di design al raggiungimento dei risultati.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/gestione-del-progetto/metodo-di-lavoro.html#metodo-di-lavoro" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Metodo di lavoro"
+            screenReaderText: "Metodo di lavoro (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -329,7 +326,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/gestione-del-progetto/le-competenze-per-progettare-servizi-pubblici.html#le-competenze-per-progettare-servizi-pubblici" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Le competenze per progettare servizi pubblici"
+            screenReaderText: "Le competenze per progettare servizi pubblici (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -348,7 +345,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/progettazione-di-servizi.html#progettazione-di-servizi" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Progettazione di servizi"
+            screenReaderText: "Progettazione di servizi (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -367,7 +364,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/progettazione-di-servizi/progettare-un-servizio-pubblico-digitale.html#progettare-un-servizio-pubblico-digitale" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Progettare un servizio pubblico digitale"
+            screenReaderText: "Progettare un servizio pubblico digitale (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-2.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-2.yaml
@@ -243,7 +243,7 @@ components:
           - label: Argomento nel Manuale su Docs Italia  #C
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/gestione-del-progetto.html" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Gestione del progetto"
+            screenReaderText: "Gestione del progetto (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -262,7 +262,7 @@ components:
           - label: Argomento nel Manuale su Docs Italia  #C
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/progettazione-di-servizi/analizzare-il-contesto-con-un-approccio-olistico-e-sistemico.html" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Analizzare il contesto con un approccio olistico e sistemico"
+            screenReaderText: "Analizzare il contesto con un approccio olistico e sistemico (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -281,7 +281,7 @@ components:
           - label: Argomento nel Manuale su Docs Italia  #C
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/progettazione-di-servizi/conoscere-gli-utenti-e-gli-erogatori-del-servizio.html" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Conoscere gli utenti e gli erogatori del servizio"
+            screenReaderText: "Conoscere gli utenti e gli erogatori del servizio (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -300,7 +300,7 @@ components:
           - label: Argomento nel Manuale su Docs Italia  #C
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/progettazione-di-servizi/gli-strumenti-per-visualizzare-mappa-della-esperienza-del-servizio.html" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Gli strumenti per visualizzare mappe dell’esperienza del servizio"
+            screenReaderText: "Gli strumenti per visualizzare mappe dell’esperienza del servizio (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-3.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-3.yaml
@@ -271,7 +271,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -290,7 +290,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -318,7 +318,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/design-research/interviste.html#interviste" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Interviste"
+            screenReaderText: "Interviste (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -338,7 +338,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/design-research/questionari.html#questionari" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Questionari"
+            screenReaderText: "Questionari (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -358,7 +358,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/design-research/personas.html#personas-creare-i-profili-degli-utenti-tipo" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Personas: creare i profili degli utenti tipo"
+            screenReaderText: "Personas: creare i profili degli utenti tipo (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -378,7 +378,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/progettazione-di-servizi/organizzare-attivita-di-co-progettazione.html#organizzare-attivita-di-co-progettazione" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Organizzare attività di co-progettazione"
+            screenReaderText: "Organizzare attività di co-progettazione (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -398,7 +398,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/design-research/test-usabilita.html#test-di-usabilita" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Test di usabilità"
+            screenReaderText: "Test di usabilità (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-4.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-4.yaml
@@ -283,7 +283,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -312,7 +312,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/dai-bisogni-degli-utenti-ai-flussi-di-interazione.html#dai-bisogni-degli-utenti-ai-flussi-di-interazione" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Visualizzare mappe dell’esperienza del servizio"
+            screenReaderText: "Visualizzare mappe dell’esperienza del servizio (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -332,7 +332,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/dai-bisogni-degli-utenti-ai-flussi-di-interazione.html#dai-bisogni-degli-utenti-ai-flussi-di-interazione" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Dai bisogni degli utenti ai flussi di interazione"
+            screenReaderText: "Dai bisogni degli utenti ai flussi di interazione (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -352,7 +352,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/prototipare-un-servizio.html#prototipare-un-servizio" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Prototipare un servizio"
+            screenReaderText: "Prototipare un servizio (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -372,7 +372,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/design-research/test-usabilita.html#test-di-usabilita" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Test di usabilità"
+            screenReaderText: "Test di usabilità (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-5.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-5.yaml
@@ -335,7 +335,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/design-research/personas.html#personas-creare-i-profili-degli-utenti-tipo" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Personas: creare i profili degli utenti-tipo"
+            screenReaderText: "Personas: creare i profili degli utenti-tipo (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -355,7 +355,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/content-design/architettura-dell-informazione.html#architettura-dellinformazione" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Architettura dell’informazione"
+            screenReaderText: "Architettura dell’informazione (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-6.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-6.yaml
@@ -228,7 +228,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -282,7 +282,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/design-research/test-usabilita.html#test-di-usabilita" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Test di usabilità"
+            screenReaderText: "Test di usabilità (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-7.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-7.yaml
@@ -311,7 +311,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/content-design/architettura-dell-informazione.html#i-content-type-tipologie-di-contenuto" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "I content-type (tipologie di contenuto)"
+            screenReaderText: "I content-type (tipologie di contenuto) (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -331,7 +331,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/content-design/architettura-dell-informazione.html#architettura-dellinformazione" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Ontologie e standard"
+            screenReaderText: "Ontologie e standard (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-8.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-8.yaml
@@ -388,7 +388,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -428,7 +428,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/content-design/architettura-dell-informazione.html#architettura-dellinformazione" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Architettura dell’informazione"
+            screenReaderText: "Architettura dell’informazione (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -448,7 +448,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/content-design/architettura-dell-informazione.html#definizione-e-organizzazione-dei-contenuti" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Definizione e organizzazione dei contenuti"
+            screenReaderText: "Definizione e organizzazione dei contenuti (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary
@@ -465,10 +465,9 @@ components:
             Scopri gli obiettivi da porti quando scrivi per i cittadini in modo tale da rendere i contenuti di facile comprensione.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/content-design/linguaggio.html#linguaggio" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Linguaggio"
+            screenReaderText: "Linguaggio (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-9.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-3/azione-9.yaml
@@ -228,7 +228,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -268,7 +268,7 @@ components:
 
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/content-design/seo.html#seo" #M
             blank: true #M #C true if new tab for external links
-            screenReaderText: "Ottimizzazione per i motori di ricerca: SEO"
+            screenReaderText: "Ottimizzazione per i motori di ricerca: SEO (si apre in una nuova finestra)"
             icon:
               icon: sprites.svg#it-external-link #C #I #it-arrow-right | it-external-link for external links
               color: primary

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-5/azione-2.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-5/azione-2.yaml
@@ -220,7 +220,7 @@ components:
         blank: true
         externalLink:
           label: Leggi su medium
-          screenReaderText: " l'articolo completo"
+          screenReaderText: " (si apre in una nuova finestra)"
           icon:
             icon: sprites.svg#it-external-link
             size: xs
@@ -295,8 +295,7 @@ components:
             Costruisci un’interfaccia per aiutare l’utente a raggiungere ciò che cerca in modo naturale e immediato, in modo trasparente. Punti cardine di una buona interfaccia sono la coerenza tra gli elementi che la compongono, l’inclusività, l’accessibilità e la tolleranza agli errori.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
-            screenReaderText: "Il progetto dell’interfaccia utente"
+            screenReaderText: "Il progetto dell’interfaccia utente (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/il-progetto-della-interfaccia-utente.html#il-progetto-dell-interfaccia-utente" #M
             blank: true #M #C true if new tab for external links
             icon:

--- a/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-5/azione-3.yaml
+++ b/src/data/content/norme-e-riferimenti/linee-guida-di-design/requisito-4-5/azione-3.yaml
@@ -276,8 +276,7 @@ components:
             Costruisci un’interfaccia in alta fedeltà (o hi-fi), dando importanza ad aspetti visivi di progettazione grafica, dettagli, stile grafico e animazioni e tenendo come punto di riferimento il wireframe a bassa qualità (o low-fi) precedentemente progettato, per dare una resa reale del prodotto finito.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
-            screenReaderText: "Progettare e costruire in alta fedeltà"
+            screenReaderText: "Progettare e costruire in alta fedeltà (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/progettare-e-costruire-in-alta-fedelta.html#progettare-e-costruire-in-alta-fedelta" #M
             blank: true #M #C true if new tab for external links
             icon:
@@ -296,8 +295,7 @@ components:
             Utilizza approcci che garantiscano una progettazione in alta fedeltà come ad esempio responsive, mobile first e feature detection.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
-            screenReaderText: "Approccio"
+            screenReaderText: "Approccio (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/lo-sviluppo-della-interfaccia-utente.html#approccio" #M
             blank: true #M #C true if new tab for external links
             icon:
@@ -316,8 +314,7 @@ components:
             Organizza il contenuto seguendo un sistema di griglie responsivo, per mantenere una efficace esperienza utente trasversalmente ai dispositivi utilizzati.
           ctas:
           - label: Argomento nel Manuale su Docs Italia  #C
-
-            screenReaderText: "Le griglie"
+            screenReaderText: "Le griglie (si apre in una nuova finestra)"
             url: "https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/progettare-e-costruire-in-alta-fedelta.html#le-griglie" #M
             blank: true #M #C true if new tab for external links
             icon:


### PR DESCRIPTION
We need to be careful when we insert a link to an external source with a `blank: true`. We need at least an `ariaLabel` prop (for buttons) or a `screenReaderText` prop (for ctas) that states something like `" (opens in a new window)"`. For `ariaLabel` buttons we also have to repeat the label at the beginning before this declaration. 

There were also some ctas linked to internal pages incorrectly marked as `blank: true`.

For your info and review @danielaiozzo @danielenole @gianvitofanelli @zetareticoli @astagi 

Fix: #1220 

ps. a lot of reviewers just to share information and need 😺 