### PR TITLE
content(fix): remove outdated CTA from a news

### DIFF
--- a/src/data/content/community/notizie/20230927-partono-i-lavori-per-il-modello-di-sito-web-per-i-musei-civici.yaml
+++ b/src/data/content/community/notizie/20230927-partono-i-lavori-per-il-modello-di-sito-web-per-i-musei-civici.yaml
@@ -94,8 +94,20 @@ components:
            Se vuoi partecipare al percorso di co-progettazione per il modello di sito dei musei civici con Designers Italia, [compila il modulo.](https://ec.europa.eu/eusurvey/runner/coprogettazionemodellomusei) Ti aggiorneremo sugli sviluppi del progetto e sulle modalità di coinvolgimento. 
 
         - name: TextImageCta
-          title: Partecipa al progetto
-          # text: |
+          title: Ricevi aggiornamenti
+          text: |
+
+          ctas:
+
+          - label: Contattaci via email #C
+            url: mailto:contatti@designers.italia.it #M
+            icon:
+              icon: sprites.svg#it-mail #C #I
+              color: primary
+              align: middle
+              hidden: true
+              size: sm
+              addonClasses: ms-2
 
 
         - name: TextImageCta

--- a/src/data/content/community/notizie/20230927-partono-i-lavori-per-il-modello-di-sito-web-per-i-musei-civici.yaml
+++ b/src/data/content/community/notizie/20230927-partono-i-lavori-per-il-modello-di-sito-web-per-i-musei-civici.yaml
@@ -97,18 +97,6 @@ components:
           title: Partecipa al progetto
           text: |
 
-          ctas:
-          
-          - label: Compila il modulo
-            url: "https://ec.europa.eu/eusurvey/runner/coprogettazionemodellomusei"
-            icon:
-              icon: sprites.svg#it-external-link
-              color: primary
-              align: middle
-              hidden: true
-              size: sm ms-2
-            screenReaderText: " (si apre in una nuova finestra)" #C
-            blank: true
 
         - name: TextImageCta
           # title: Titoletto interno

--- a/src/data/content/community/notizie/20230927-partono-i-lavori-per-il-modello-di-sito-web-per-i-musei-civici.yaml
+++ b/src/data/content/community/notizie/20230927-partono-i-lavori-per-il-modello-di-sito-web-per-i-musei-civici.yaml
@@ -95,7 +95,7 @@ components:
 
         - name: TextImageCta
           title: Partecipa al progetto
-          text: |
+          # text: |
 
 
         - name: TextImageCta


### PR DESCRIPTION
…-musei-civici.yaml

I removed the link to the CTA about filling up the form, as that has been closed a couple of months ago.