### PR TITLE
fix: feedback radio fieldset inline spacing

### DIFF
--- a/src/components/feedback/feedback.js
+++ b/src/components/feedback/feedback.js
@@ -117,11 +117,11 @@ function Feedback() {
               </span>
             </h2>
             <form className="mt-3 mt-md-3">
-              <fieldset className="d-flex">
+              <fieldset>
                 <legend>
                   <span className="visually-hidden">Scegli la risposta:</span>
                 </legend>
-                <div className="form-check me-4">
+                <div className="form-check form-check-inline">
                   <input
                     name="feedbackValue"
                     type="radio"
@@ -133,7 +133,7 @@ function Feedback() {
                     Sì
                   </label>
                 </div>
-                <div className="form-check">
+                <div className="form-check form-check-inline">
                   <input
                     name="feedbackValue"
                     type="radio"


### PR DESCRIPTION
Probable cause: this commit on Bootstrap Italia: https://github.com/italia/bootstrap-italia/commit/fc88721743c838cec67946f7b0865ee6aba809af

![bug](https://github.com/user-attachments/assets/5029805c-ce4b-4236-aa32-e208de78e930)

cc @astagi @zetareticoli 