### PR TITLE
refactor: last update styles

### DIFF
--- a/src/components/last-update/last-update.js
+++ b/src/components/last-update/last-update.js
@@ -18,13 +18,13 @@ function LastUpdate({ pathname, lastModified, noPadding }) {
   const paddingStyle = classNames("px-3", { "px-lg-5": !noPadding });
 
   return (
-    <div className="last-update py-5 py-lg-7">
+    <div className="last-update py-5">
       <div className="container-xxl">
         <div className="row">
           <div className={columnStyle}>
-            <div className={paddingStyle}>
-              <div className="mb-4">
-                <span>Ultimo aggiornamento: </span>
+            <div className={classNames("d-flex flex-column flex-lg-row justify-content-lg-between", paddingStyle)}>
+              <div className="text-secondary mb-2 mb-lg-0">
+                <strong>Ultimo aggiornamento: </strong>
                 <time dateTime={lastModified} title={lastModified}>
                   {new Date(lastModified).toLocaleDateString("it-IT", {
                     year: "numeric",
@@ -32,44 +32,40 @@ function LastUpdate({ pathname, lastModified, noPadding }) {
                     day: "numeric",
                   })}
                 </time>
+              </div>
+              <div>
                 <Link
                   to="https://creativecommons.org/licenses/by-sa/4.0/deed.it"
                   target="_blank"
                   rel="noreferrer"
-                  className="d-block d-md-inline-block text-decoration-none mt-2 mt-md-0 ms-md-5"
+                  className="text-secondary me-4"
                 >
-                  <strong className="me-2">
-                    Licenza CC BY-SA 4.0
-                    <span className="visually-hidden">
-                      (si apre in una nuova finestra)
-                    </span>
-                  </strong>
+                  Licenza CC BY-SA 4.0
+                  <span className="visually-hidden">
+                    (si apre in una nuova finestra)
+                  </span>
                   <Icon
                     icon="sprites.svg#it-external-link"
                     size="sm"
-                    color="primary"
-                    addonClasses="mb-1"
+                    color="secondary"
+                    addonClasses="ms-1 mb-1"
                   />
                 </Link>
-              </div>
-              <div className="mb-0">
                 <Link
                   to={editGithubUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="d-inline-block text-decoration-none"
+                  className="d-inline-block text-secondary"
                 >
-                  <strong className="me-2">
-                    Proponi una modifica a questa pagina
-                    <span className="visually-hidden">
-                      (si apre in una nuova finestra)
-                    </span>
-                  </strong>
+                  Proponi una modifica a questa pagina
+                  <span className="visually-hidden">
+                    (si apre in una nuova finestra)
+                  </span>
                   <Icon
                     icon="sprites.svg#it-pencil"
                     size="sm"
-                    color="primary"
-                    addonClasses="mb-1"
+                    color="secondary"
+                    addonClasses="ms-1 mb-1"
                   />
                 </Link>
               </div>

--- a/src/components/last-update/last-update.scss
+++ b/src/components/last-update/last-update.scss
@@ -1,6 +1,10 @@
 
 @import "../../scss/bootstrap-breakpoints";
 
+.last-update {
+  border-top: var(--hero-kangaroo-zone-border-top);
+}
+
 //mobile only ------------------------------------------------------------------------------------------
 @include media-breakpoint-down(sm) {
 
@@ -22,12 +26,12 @@
 }
 
 //Laptop ------------------------------------------------------------------------------------------------
-@include media-breakpoint-up(xl) {
-  .last-update {
-    padding-top: calc(var(--spacer) * 24) !important;
-    padding-bottom: calc(var(--spacer) * 24) !important;
-  }
-}
+// @include media-breakpoint-up(xl) {
+//   .last-update {
+//     padding-top: calc(var(--spacer) * 24) !important;
+//     padding-bottom: calc(var(--spacer) * 24) !important;
+//   }
+// }
 
 //Desktop -----------------------------------------------------------------------------------------------
 @include media-breakpoint-up(xxl) {


### PR DESCRIPTION
Rivisti gli stili del componente `last update` con l'obiettivo di:
- ridurre lo spazio verticale occupato, sopratutto su dispositivi medio/grandi
- ridurre l'importanza visiva dei links che a volte si sovrapponevano alle CTA presenti in pagina
- corretta la sottolineatura presenta sui links