### PR TITLE
chore: add build ci specific workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           npm ci --prefer-offline
           SHARP_CONCURRENCY=2 \
           GATSBY_CONCURRENT_DOWNLOAD=5 \
-          npm run build
+          npm run build:ci
         env:
           MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}
           MATOMO_SITE_URL: ${{ secrets.MATOMO_SITE_URL }}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "prettier:fix": "npm run prettier -- --write",
     "build:dev": "npm run clean && npm run prepare-lib && GATSBY_BUILD=dev gatsby build --prefix-paths",
     "build": "npm run clean && npm run prepare-lib && gatsby build --prefix-paths",
+    "build:ci": "npm run prepare-lib && gatsby build --prefix-paths",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "deploy": "gh-pages -u 'Deploy Bot <no-reply@teamdigitale.governo.it>' -d public"


### PR DESCRIPTION
This PR removes the "clean" function in the deployment workflow to enable the use of Gatsby Cache.