### PR TITLE
fix: update hero.yaml

### DIFF
--- a/src/data/content/design-system/componenti/hero.yaml
+++ b/src/data/content/design-system/componenti/hero.yaml
@@ -98,7 +98,7 @@ tabs:
               azioni. 
 
               - Usare il componente Hero con approccio "fullwidth", sfrutta cioè
-              tutta la larghezza della viewport.
+              tutta la larghezza del container.
 
 
               ### Buone pratiche sui contenuti


### PR DESCRIPTION
corrected the suggestion to use the hero with fullwidth respect to the container instead of the viewport