### PR TITLE
fix: update Hero component width description

### DIFF
--- a/src/data/content/design-system/componenti/hero.yaml
+++ b/src/data/content/design-system/componenti/hero.yaml
@@ -98,7 +98,7 @@ tabs:
               azioni. 
 
               - Usare il componente Hero con approccio "fullwidth", sfrutta cioè
-              tutta la larghezza della viewport.
+              tutta la larghezza del container di riferimento.
 
 
               ### Buone pratiche sui contenuti


### PR DESCRIPTION
Sostituisce la parola `viewport` con `container`