### PR TITLE
docs: aggiunge esempio pratico sull'accessibilità delle modali

### DIFF
--- a/src/data/content/design-system/fondamenti/accessibilita.yaml
+++ b/src/data/content/design-system/fondamenti/accessibilita.yaml
@@ -371,6 +371,7 @@ components:
               - il focus è visibile;
               - non sono presenti "keyboard traps";
               - comportamento delle modali.
+              - esempio pratico in inglese di una regressione del focus in una [modale non accessibile agli screen reader](https://frontendatlas.com/incidents/modal-screen-reader-failure), come esercizio supplementare che non sostituisce i test con tecnologie assistive o la ricerca con utenti.
 
             ##### Ingrandimento
             Supportare l'ingrandimento, nativo del browser, fino a 400% per viewport larghe 1280px, e laddove esistano elementi con scroll orizzontale, per viewport larghe 1024px.


### PR DESCRIPTION
## Riepilogo

- Aggiunge alla checklist delle interazioni via tastiera un esempio pratico, in inglese, di una regressione del focus in una modale.
- Specifica che l'esercizio è supplementare e non sostituisce i test con tecnologie assistive o la ricerca con utenti.

L'esempio mostra problemi collegati a focus iniziale, focus trap e ripristino del focus, semantica del dialogo, nome accessibile e isolamento dei contenuti sullo sfondo.

## Verifica

- Differenza netta: una riga YAML aggiunta, nessuna rimozione.
- Il 3 settembre 2026 la pagina di destinazione ha restituito HTTP 200 ed era self-canonical e indicizzabile.
- Non è stata eseguita una build locale; si tratta di una modifica documentale tramite l'interfaccia web di GitHub.

## Trasparenza

Sono il creatore e maintainer di FrontendAtlas. L'esercizio collegato è gratuito; la piattaforma più ampia include anche contenuti a pagamento. Ho usato assistenza AI per preparare questa pull request e ho verificato personalmente il testo finale. Non richiedo pagamento, affiliazione, link reciproci o trattamenti speciali del link.